### PR TITLE
add :wait t option to speak-en

### DIFF
--- a/pr2eus/speak.l
+++ b/pr2eus/speak.l
@@ -20,21 +20,43 @@
 <vtml_volume value=\"100\">text</vtml_volume> ;; 0-500%
 ^^ ;;数字の棒読み
 |#
-(defun speak-en (en-str &key (google nil))
+(defun speak-en (en-str &key (google nil) (wait nil))
   (unless (ros::get-topic-publisher "robotsound")
     (ros::advertise "robotsound" sound_play::SoundRequest 5)
     (unix:sleep 1))
-  (if google
-      (ros::publish "robotsound"
-                    (instance sound_play::SoundRequest :init
-                              :sound sound_play::SoundRequest::*play_file*
-                              :command sound_play::SoundRequest::*play_once*
-                              :arg (concatenate string "http://translate.google.com/translate_tts?tl=en&q=" en-str)
-                              ))
-    (ros::publish "robotsound"
-                  (instance sound_play::SoundRequest :init
-                            :sound sound_play::SoundRequest::*say*
-                            :command sound_play::SoundRequest::*play_once*
-                            :arg en-str
-                            ))
+  (let (sound-msg)
+    (if google
+        (setq sound-msg
+              (instance sound_play::SoundRequest :init
+                        :sound sound_play::SoundRequest::*play_file*
+                        :command sound_play::SoundRequest::*play_once*
+                        :arg (concatenate string "http://translate.google.com/translate_tts?tl=en&q=" en-str)
+                        ))
+      (setq sound-msg
+            (instance sound_play::SoundRequest :init
+                      :sound sound_play::SoundRequest::*say*
+                      :command sound_play::SoundRequest::*play_once*
+                      :arg en-str
+                      ))
+      )
+    (if wait
+        (let ((sound-request-action (instance ros::simple-action-client :init
+                                              "/sound_play" sound_play::SoundRequestAction
+                                              :groupname "speak"))
+              goal
+              )
+          (if (send sound-request-action :wait-for-server 3)
+              (progn
+                (setq goal (instance sound_play::SoundRequestActionGoal :init))
+                (send goal :goal :sound_request sound-msg)
+                (send sound-request-action :send-goal goal)
+                (send sound-request-action :wait-for-result)
+                (send sound-request-action :get-result)
+                )
+            (ros::ros-warn "No sound_play action found")
+            )
+          )
+      (ros::publish "robotsound" sound-msg)
+      )
     )
+  )


### PR DESCRIPTION
ros-drivers/audio_common#41 is merged.
This will enable user to wait until speak end.

```
(speak-en "This is testing. Test. Test. Test" :google t :wait t)
```
