### PR TITLE
added inverse-reachabirity with-given-coords

### DIFF
--- a/pr2eus/pr2-utils.l
+++ b/pr2eus/pr2-utils.l
@@ -122,8 +122,8 @@
 	     )
 	 (setq target-coords-transformed (send (send (send target-coords :copy-worldcoords) :transformation (elt base-coords-list i) :local) :transformation (make-coords) :local))
 	 )
-       (if (forward-message-to self (cons :inverse-kinematics (cons target-coords-transformed 
-				      (cdr args))))
+       (if (send* self :inverse-kinematics target-coords-transformed 
+				      (cdr args))
 	   (setq result-coords-list (append result-coords-list (list (elt base-coords-list i)))))
        (send self :angle-vector initial-angle-vector))
      result-coords-list


### PR DESCRIPTION
https://github.com/jsk-ros-pkg/jsk_demos/pull/95
を受けてinverse-reachability-mapを計算するコードです。
coordsのリストを与えてすべてIKを解いた上で、IKが解けるcoordsだけ返り値として返ってきます。
![inverse-reach-befor](https://cloud.githubusercontent.com/assets/7259700/5486985/ef3dc786-86ef-11e4-9944-dae83bec23dd.png)
![inverse-reach-result](https://cloud.githubusercontent.com/assets/7259700/5486988/f0da78c8-86ef-11e4-80f0-1fb1902c937f.png)
目標の手先位置がBOXで表示されていて、目標の手先位置三つ与えた上で、
すべてを解ける場所だけを座標で表示しています(2枚目の画像)。
