### PR TITLE
do not use limited buffer for publishing joint state

### DIFF
--- a/pr2eus/robot-interface.l
+++ b/pr2eus/robot-interface.l
@@ -101,7 +101,7 @@
                         (namespace
                          (format nil "~A/~A" namespace joint-states-topic))
                         (t joint-states-topic))
-                       sensor_msgs::JointState 1)
+                       sensor_msgs::JointState)
        ))
    self)
   ;;


### PR DESCRIPTION
fix: do not use limited buffer for publishing joint state at simulation mode
