### PR TITLE
(pr2eus/robot-interface.l): Add validity check for tm in angle-vector

### DIFF
--- a/pr2eus/robot-interface.l
+++ b/pr2eus/robot-interface.l
@@ -160,6 +160,11 @@
      msg))
   (:angle-vector
    (av &optional (tm 3000) (ctype controller-type) (start-time 0))
+   ;; check validity of tm
+   (unless (numberp tm)
+     (warn ";; interpolation time is not a number: ~A~%" tm)
+     (return-from :angle-vector)
+     )
    ;; check max-joint-velocity
    (let ((idx 0)
          (diff-av (v- av (or (send self :state :potentio-vector) (send robot :angle-vector)))))

--- a/pr2eus/robot-interface.l
+++ b/pr2eus/robot-interface.l
@@ -162,7 +162,7 @@
    (av &optional (tm 3000) (ctype controller-type) (start-time 0))
    ;; check validity of tm
    (unless (numberp tm)
-     (warn ";; interpolation time is not a number: ~A~%" tm)
+     (ros::ros-error "interpolation time is not a number: ~A" tm)
      (return-from :angle-vector)
      )
    ;; check max-joint-velocity


### PR DESCRIPTION
When using limb-controller, a user have to define tm by oneself because of optional argument order in current robot-interface.
If a user send false input like
```
(send *ri* :angle-vector <float-vector> <limb-controller>)
```
, max joint velocity is stored in tm, angle-vector is sent to fullbody-controller and this causes unintended whole-body motion in maximum joint velocity.
To prevent uninteded motion, check validity of tm and if it is incorrect, angle-vector would be better to return without any effects.
