### PR TITLE
change default 5 to 1 as :scale in angle-vector

### DIFF
--- a/pr2eus/robot-interface.l
+++ b/pr2eus/robot-interface.l
@@ -228,7 +228,7 @@
      warning))
 
   (:angle-vector-duration
-   (start end &optional (scale 5) (min-time 1.0) (ctype controller-type))
+   (start end &optional (scale 1) (min-time 1.0) (ctype controller-type))
    (let* ((unordered-joint-names 
            (flatten (mapcar #'(lambda (joint-param)
                                 (cdr (assoc :joint-names joint-param)))
@@ -246,7 +246,7 @@
          (let ((max-time (apply #'max time-list)))
            (max max-time min-time))))))
   (:angle-vector
-   (av &optional (tm nil) (ctype controller-type) (start-time 0) &key (scale 5) (min-time 1.0))
+   (av &optional (tm nil) (ctype controller-type) (start-time 0) &key (scale 1) (min-time 1.0))
    "tm (time to goal in msec)
    if designated tm is faster than fastest speed, use fastest speed
    if not specified, it will use 1/5 of the fastest speed .
@@ -298,7 +298,7 @@
       cacts (send self ctype)))
    av)
   (:angle-vector-sequence
-   (avs &optional (tms (list 3000)) (ctype controller-type) (start-time 0.1) &key (scale 5) (min-time 1.0))
+   (avs &optional (tms (list 3000)) (ctype controller-type) (start-time 0.1) &key (scale 1) (min-time 1.0))
    (unless (gethash ctype controller-table)
      (warn ";; controller-type: ~A not found" ctype)
      (return-from :angle-vector-sequence))

--- a/pr2eus/robot-interface.l
+++ b/pr2eus/robot-interface.l
@@ -249,7 +249,7 @@
    (av &optional (tm nil) (ctype controller-type) (start-time 0) &key (scale 1) (min-time 1.0))
    "tm (time to goal in msec)
    if designated tm is faster than fastest speed, use fastest speed
-   if not specified, it will use 1/5 of the fastest speed .
+   if not specified, it will use 1/scale of the fastest speed .
    if :fastest is specefied use fastest speed calcurated from max speed"
    (unless (gethash ctype controller-table)
      (warn ";; controller-type: ~A not found" ctype)


### PR DESCRIPTION
This change may affects on baxter interface.
So please change :scale of baxter's angle-vector to 5 @aginika 

ref: https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/120