### PR TITLE
angle-vector-sequence の最後の姿勢が kinematics simulator で若干ずれる

### DIFF
--- a/pr2eus/robot-interface.l
+++ b/pr2eus/robot-interface.l
@@ -366,6 +366,9 @@
                (if viewer (send self :draw-objects)))))
          ;;
          (send robot :angle-vector av)
+	 (when (send self :simulation-modep)
+	   (send self :publish-joint-state)
+	   (if viewer (send self :draw-objects)))
          (push (list av
                      (copy-seq vel)  ;; velocities
                      (/ (+ st tm) 1000.0)) ;; tm + duration


### PR DESCRIPTION
angle-vector-sequence の最後の姿勢を publish-joint-state して kinematics simulator を draw-objcects する変更を加えました。

* test code

```
(hrp2jsknt-init)
(setq *robot* *hrp2jsknt*)
(send *ri* :angle-vector-sequence
      (list
       (copy-seq (send *robot* :reset-pose))
       (copy-seq (send *robot* :reset-manip-pose))
       (copy-seq (send *robot* :reset-pose))
       (copy-seq (send *robot* :reset-manip-pose))
       (copy-seq (send *robot* :reset-pose))
       (copy-seq (send *robot* :reset-manip-pose)))
      (list
       100 100
       100 100
       100 100))
(v- (send *robot* :angle-vector) (send (send *ri* :get-val 'robot) :angle-vector)) ;; equal zero
(v- (send *ri* :state :potentio-vector) (send (send *ri* :get-val 'robot) :angle-vector))) ;; equal zero
(v- (send *robot* :angle-vector) (send (send *ri* :get-val 'robot) :angle-vector))  ;; not zero !!!
```
