### PR TITLE
	[pr2eus] Fix :interpolatingp by using ros::*simple-goal-state-active* instead of actoinlib_msgs::GoalStatus::*active*

### DIFF
--- a/pr2eus/robot-interface.l
+++ b/pr2eus/robot-interface.l
@@ -401,9 +401,9 @@
     (cond
      (ctype
       (let ((cacts (gethash ctype controller-table)))
-        (some #'(lambda (x) (eq x actionlib_msgs::GoalStatus::*active*))
+        (some #'(lambda (x) (eq x ros::*simple-goal-state-active*))
               (send-all cacts :get-state))))
-     (t (some #'(lambda (x) (eq x actionlib_msgs::GoalStatus::*active*))
+     (t (some #'(lambda (x) (eq x ros::*simple-goal-state-active*))
               (send-all controller-actions :get-state)))))
   (:wait-interpolation-smooth (time-to-finish &optional (ctype))
     (while (null (send self :interpolating-smoothp time-to-finish ctype))

--- a/pr2eus/robot-interface.l
+++ b/pr2eus/robot-interface.l
@@ -398,7 +398,13 @@
     (t (send-all controller-actions :wait-for-result :timeout timeout))))
   (:interpolatingp (&optional (ctype)) ;; controller-type ;; check someone is moving
     (send self :spin-once)
-    (some #'(lambda (x) (eq x actionlib_msgs::GoalStatus::*active*)) (send-all controller-actions :get-state)))
+    (cond
+     (ctype
+      (let ((cacts (gethash ctype controller-table)))
+        (some #'(lambda (x) (eq x actionlib_msgs::GoalStatus::*active*))
+              (send-all cacts :get-state))))
+     (t (some #'(lambda (x) (eq x actionlib_msgs::GoalStatus::*active*))
+              (send-all controller-actions :get-state)))))
   (:wait-interpolation-smooth (time-to-finish &optional (ctype))
     (while (null (send self :interpolating-smoothp time-to-finish ctype))
       (send self :ros-wait 0.005)))


### PR DESCRIPTION
@orikuma 