### PR TITLE
[pr2eus] pass additional-weight-list when calling super class method

### DIFF
--- a/pr2eus/pr2-utils.l
+++ b/pr2eus/pr2-utils.l
@@ -30,6 +30,7 @@
                          (t (make-list (length target-coords) :initial-element (deg2rad 5)))))
 		  (base-range (list :min #f(-30 -30 -30)
 				   :max #f( 30  30  30)))
+                  (additional-weight-list)
                   &allow-other-keys)
    (let (diff-pos-rot)
      ;;
@@ -87,11 +88,14 @@
                      :thre thre
                      :stop stop
                      :additional-weight-list
-                     (list
-                      (list (send self :torso_lift_joint :child-link)
-                            (if (numberp use-torso) use-torso 0.005))
-                      (list (car (send self :links))
-                            (if (eq use-base t) 0.1 use-base))
+                     (append
+                      (list
+                       (list (send self :torso_lift_joint :child-link)
+                             (if (numberp use-torso) use-torso 0.005))
+                       (list (car (send self :links))
+                             (if (eq use-base t) 0.1 use-base))
+                       )
+                      additional-weight-list
                       )
                      :link-list (car ll) ;; link-list
                      :move-target move-target


### PR DESCRIPTION
This PR is necessary to do following
https://github.com/jsk-ros-pkg/jsk_model_tools/issues/119#issuecomment-114086317
```
2 use arm end coords but set small weight ( I suppose use greater number for eus arguments?) not to move
arms . Of cause, arm initial arm postures is set to grab object no the ground. From the kinematics point of 
view, this is almost equals to 1. So it should move.
```
@aginika 