### PR TITLE
[pr2eus] add wait option in simulation mode

### DIFF
--- a/pr2eus/pr2-interface.l
+++ b/pr2eus/pr2-interface.l
@@ -109,9 +109,11 @@
    (send-super :publish-joint-state (append (send robot :joint-list) (send robot :larm :gripper :joint-list) (send robot :rarm :gripper :joint-list))))
   ;;
   (:wait-interpolation (&rest args);; overwrite for pr2, due to some joint is stll moving after joint-trajectry-action stops
-   (unless joint-action-enable (return-from :wait-interpolation
-                                 (make-sequence cons (length controller-actions)
-                                                :initial-element t)))
+   (unless joint-action-enable
+     (send-super :wait-interpolation (car args) (cadr args) (caddr args))
+     (return-from :wait-interpolation
+       (make-sequence cons (length controller-actions)
+                      :initial-element t)))
    (let (result)
      (ros::ros-info "wait-interpolation debug: start")
    ;;  (setq result (send-all controller-actions :wait-for-result))

--- a/pr2eus/robot-interface.l
+++ b/pr2eus/robot-interface.l
@@ -52,7 +52,7 @@
   :slots (robot objects robot-state joint-action-enable warningp
                 controller-type controller-actions controller-timeout
                 namespace controller-table ;; hashtable :type -> (action)
-                visualization-topic
+                visualization-topic simulation-finish-time
                 joint-states-topic pub-joint-states-topic
                 viewer groupname)
   :documentation "robot-interface is object for interacting real robot thorugh JointTrajectoryAction servers and JointState topics, this function uses old nervous-style interface for histrical reason. If JointTrajectoryAcion serve is not found, this instance runs as simulation mode, see \"Kinematics Simulator\" view as simulatied robot,
@@ -321,6 +321,7 @@
      )
    ;; for simulation mode
    (when (send self :simulation-modep)
+     (setq simulation-finish-time (ros::time+ (ros::time-now) (ros::time (/ tm 1000.0))))
      (if av (send self :angle-vector-simulation av tm ctype)))
    (send robot :angle-vector av)
    (let ((cacts (gethash ctype controller-table)))
@@ -354,6 +355,13 @@
       ((> (length tms) (length avs))
        (ros::ros-warn "length of tms should be the same or smaller than avs")
        (setq tms (subseq tms 0 (length avs)))))
+     (when (send self :simulation-modep)
+       (let ((sumtm 0))
+         (dolist (stm tms)
+           (setq sumtm (+ sumtm stm))
+           )
+         (setq simulation-finish-time (ros::time+ (ros::time-now) (ros::time (/ sumtm 1000.0))))
+         ))
      (prog1 ;; angle-vector-sequence returns avs
          avs
        (while avs
@@ -432,19 +440,27 @@
                     traj-points))
           cacts (send self ctype)))
        )))
-  (:wait-interpolation (&optional (ctype) (timeout 0)) ;; controller-type
+  (:wait-interpolation (&optional (ctype) (timeout 0) (real-time-simulation nil)) ;; controller-type
    "Wait until last sent motion is finished
 - ctype : controller to be wait
 - timeout : max time of for waiting"
    (when (send self :simulation-modep)
+     (while (and real-time-simulation (and simulation-finish-time (ros::time< (ros::time-now) simulation-finish-time)))
+       (unix:usleep 10000))
      (return-from :wait-interpolation nil))
    (cond
     (ctype
      (let ((cacts (gethash ctype controller-table)))
        (send-all cacts :wait-for-result :timeout timeout)))
     (t (send-all controller-actions :wait-for-result :timeout timeout))))
-  (:interpolatingp (&optional (ctype)) ;; controller-type ;; check someone is moving
+  (:interpolatingp (&optional (ctype) (real-time-simulation nil)) ;; controller-type ;; check someone is moving
 "Check inf the last sent motion is executing"
+    (when (send self :simulation-modep)
+      (cond
+        ((and real-time-simulation (and simulation-finish-time (ros::time< (ros::time-now) simulation-finish-time)))
+         (return-from :interpolatingp t))
+        (t
+         (return-from :interpolatingp nil))))
     (send self :spin-once)
     (cond
      (ctype


### PR DESCRIPTION
In simulation, `wait-interpolation` do nothing.
I add wait mode which simulate execution duraction.
For example, if you write like below, `:wait-interpolation` immediately return.
```
(send *ri* :angle-vector (send *pr2* :angle-vector) 3000)
(send *ri* :wait-interpolation nil 0 nil)
```
But, if you write like below, after 3sec `:wait-interpolation` return.
```
(send *ri* :angle-vector (send *pr2* :angle-vector) 3000)
(send *ri* :wait-interpolation nil 0 t)
```
