### PR TITLE
add more realistic simulation mode  rev 2

### DIFF
--- a/pr2eus/pr2-interface.l
+++ b/pr2eus/pr2-interface.l
@@ -29,7 +29,10 @@
                            move-base-action move-base-trajectory-action
                            finger-pressure-origin
                            move-base-goal-msg move-base-goal-coords  move-base-goal-map-to-frame
-                           go-pos-unsafe-goal-msg))
+                           go-pos-unsafe-goal-msg
+                           current-goal-coords ;; for simulation-callback
+                           ))
+
 (defmethod pr2-interface
   (:init
    (&rest args &key (type :default-controller)
@@ -379,18 +382,14 @@
      
   (:move-to
    (coords &rest args &key (no-wait nil) &allow-other-keys)
-   (if (send self :simulation-modep)
-     (let ((orig-coords (send robot :copy-worldcoords)))
-       (do ((curr-tm 0.0 (+ curr-tm 100.0)))
-           ((> curr-tm 1000))
-	   (send robot :newcoords (midcoords (/ curr-tm 1000.0) orig-coords coords))
-	   (if viewer (send self :draw-objects))))
-     (return-from :move-to t))
    (send* self :move-to-send coords args)
    (if (not no-wait)
        (send* self :move-to-wait args)))
   (:move-to-send
    (coords &key (frame-id "/world") (wait-for-server-timeout 5) (count 0) &allow-other-keys)
+   (if (send self :simulation-modep)
+       (let ((orig-coords (send robot :copy-worldcoords)))
+         (setq current-goal-coords (send coords :transform robot :world)))) ;; for simulation-callback
    (let (ret (count 0) (tm (ros::time-now))
 	     (map-to-frame (send *tfl* :lookup-transform "/map" frame-id (ros::time 0))))
      ;; store in slot variable for :move-to-wait
@@ -422,6 +421,11 @@
    (let (ret (count 0) (tm (ros::time-now))
 	     (map-to-frame move-base-goal-map-to-frame)
              (coords move-base-goal-coords))
+     (if (send self :simulation-modep)
+         ;; wait for-result
+         (while current-goal-coords
+           (send self :robot-interface-simulation-callback))
+         (return-from :move-to-no-wait t)) ;; simlation-modep
      (if (null move-base-goal-msg) (return-from :move-to-wait nil))
      (while (and (null ret) (<= count retry))
        (when (> count 0) ;; retry
@@ -733,6 +737,22 @@ send-action [ send message to action server, it means robot will move ]"
                        controller-actions)))
      (when act
        (send act :wait-for-result :timeout timeout))))
+  ;;;
+  (:robot-interface-simulation-callback ()
+   (let ((orig-coords (send robot :copy-worldcoords))
+         diff-pos diff-rot diff)
+     (when current-goal-coords
+       (setq diff-pos (send orig-coords :difference-position current-goal-coords)
+             diff-rot (send orig-coords :difference-rotation current-goal-coords :rotation-axis :xy))
+       (cond ((and (eps= (norm diff-pos) 0) (eps= (norm diff-rot) 0))
+              (setq current-goal-coords nil))
+             (t
+              (send robot :newcoords (midcoords (min (/ 10 (max (norm diff-pos) 10))
+                                                     (/ 0.02 (max (norm diff-rot) 0.02)))
+                                                orig-coords current-goal-coords))))
+       );; when
+     (send-super :robot-interface-simulation-callback)
+     ))
   )
 
 ;;

--- a/pr2eus/pr2-interface.l
+++ b/pr2eus/pr2-interface.l
@@ -387,14 +387,15 @@
        (send* self :move-to-wait args)))
   (:move-to-send
    (coords &key (frame-id "/world") (wait-for-server-timeout 5) (count 0) &allow-other-keys)
+   (setq move-base-goal-msg (instance move_base_msgs::MoveBaseActionGoal :init))
+   (setq move-base-goal-coords coords)
    (if (send self :simulation-modep)
        (let ((orig-coords (send robot :copy-worldcoords)))
-         (setq current-goal-coords (send coords :transform robot :world)))) ;; for simulation-callback
+         (setq current-goal-coords (send coords :transform robot :world)) ;; for simulation-callback
+         (return-from :move-to-send)))
    (let (ret (count 0) (tm (ros::time-now))
 	     (map-to-frame (send *tfl* :lookup-transform "/map" frame-id (ros::time 0))))
      ;; store in slot variable for :move-to-wait
-     (setq move-base-goal-msg (instance move_base_msgs::MoveBaseActionGoal :init))
-     (setq move-base-goal-coords coords)
      (setq move-base-goal-map-to-frame map-to-frame)
      ;;
      (when (not (send move-base-action :wait-for-server wait-for-server-timeout))

--- a/pr2eus/pr2-interface.l
+++ b/pr2eus/pr2-interface.l
@@ -398,7 +398,7 @@
      (setq move-base-goal-map-to-frame map-to-frame)
      ;;
      (when (not (send move-base-action :wait-for-server wait-for-server-timeout))
-       (return-from :move-to))
+       (return-from :move-to-send))
      ;;
      (send move-base-goal-msg :header :stamp tm)
      (send move-base-goal-msg :goal :target_pose :header :stamp tm)
@@ -421,11 +421,11 @@
    (let (ret (count 0) (tm (ros::time-now))
 	     (map-to-frame move-base-goal-map-to-frame)
              (coords move-base-goal-coords))
-     (if (send self :simulation-modep)
+     (when (send self :simulation-modep)
          ;; wait for-result
          (while current-goal-coords
            (send self :robot-interface-simulation-callback))
-         (return-from :move-to-no-wait t)) ;; simlation-modep
+         (return-from :move-to-wait t)) ;; simlation-modep
      (if (null move-base-goal-msg) (return-from :move-to-wait nil))
      (while (and (null ret) (<= count retry))
        (when (> count 0) ;; retry

--- a/pr2eus/pr2-interface.l
+++ b/pr2eus/pr2-interface.l
@@ -111,9 +111,7 @@
    (send-super :publish-joint-state (append (send robot :joint-list) (send robot :larm :gripper :joint-list) (send robot :rarm :gripper :joint-list))))
   ;;
   (:wait-interpolation (&rest args);; overwrite for pr2, due to some joint is stll moving after joint-trajectry-action stops
-   (unless joint-action-enable (return-from :wait-interpolation
-                                 (make-sequence cons (length controller-actions)
-                                                :initial-element t)))
+   (when (send self :simulation-modep) (return-from :wait-interpolation (send-super :wait-interpolation)))
    (let (result)
      (ros::ros-info "wait-interpolation debug: start")
    ;;  (setq result (send-all controller-actions :wait-for-result))

--- a/pr2eus/robot-interface.l
+++ b/pr2eus/robot-interface.l
@@ -474,7 +474,8 @@
   (:wait-interpolation (&optional (ctype) (timeout 0)) ;; controller-type
    "Wait until last sent motion is finished
 - ctype : controller to be wait
-- timeout : max time of for waiting"
+- timeout : max time of for waiting
+- return values is a list of interpolatingp for all controllers, so (null (some #'identity (send *ri* :wait-interpolation))) -> t if all interpolation has stopped"
    (when (send self :simulation-modep)
      (while (some #'(lambda (a) (send a :interpolatingp)) controller-actions)
        (send self :robot-interface-simulation-callback))
@@ -485,7 +486,8 @@
        (send-all cacts :wait-for-result :timeout timeout)))
     (t (send-all controller-actions :wait-for-result :timeout timeout))))
   (:interpolatingp (&optional (ctype)) ;; controller-type ;; check someone is moving
-"Check inf the last sent motion is executing"
+"Check if the last sent motion is executing
+return t if interpolating"
     (send self :spin-once)
     (cond
      (ctype
@@ -499,7 +501,7 @@
 	(dolist (av (list av1 av2 av3 av4))
 	    (send *ri* :angle-vector av)
 	    (send *ri* :wait-interpolation-smooth 300))
-"
+Return value is a list of interpolatingp for all controllers, so (null (some #'identity (send *ri* :wait-interpolation))) -> t if all interpolation has stopped"
     (while (null (send self :interpolating-smoothp time-to-finish ctype))
       (send self :ros-wait 0.005)))
   (:interpolating-smoothp (time-to-finish &optional (ctype)) ;; controller-type

--- a/pr2eus/robot-interface.l
+++ b/pr2eus/robot-interface.l
@@ -27,9 +27,12 @@
 
 (defclass controller-action-client
   :super ros::simple-action-client
-  :slots (time-to-finish))
+  :slots (time-to-finish
+          ri angle-vector-sequence timer-sequence current-time current-angle-vector previous-angle-vector scale-angle-vector;; slot for angle-vector-sequence
+          ))
 (defmethod controller-action-client
-  (:init (&rest args)
+  (:init (r &rest args)
+    (setq ri r) ;; robot-interface
     (setq time-to-finish 0)
     (send-super* :init args))
   (:time-to-finish ()
@@ -45,6 +48,27 @@
                     (send msg :status :goal_id :id))
        (setq time-to-finish (send (ros::time- finish-time current-time) :to-sec)))
      ))
+  ;; method for simulatio-modep
+  (:push-angle-vector-simulation (av tm &optional prev-av)
+   (setq previous-angle-vector prev-av)
+   (setq angle-vector-sequence (append angle-vector-sequence (list av)))
+   (setq timer-sequence (append timer-sequence (list tm)))
+   (setq current-time 0)
+   av)
+  (:pop-angle-vector-simulation ()
+    (let ((av (car angle-vector-sequence)) (tm (car timer-sequence)) scale-av)
+      (when tm
+        (setq scale-av (send ri :sub-angle-vector av previous-angle-vector))
+        (setq av (v+ previous-angle-vector (scale (/ current-time tm) scale-av)))
+        (incf current-time 100.0)
+        (when (> current-time tm)
+          (pop timer-sequence)
+          (pop angle-vector-sequence)
+          (setq previous-angle-vector av)
+          (setq current-time 0)
+          )
+        av)))
+  (:interpolatingp () (not (null timer-sequence)))
   )
 
 (defclass robot-interface
@@ -144,6 +168,9 @@
                          (format nil "~A/~A" namespace joint-states-topic))
                         (t joint-states-topic))
                        sensor_msgs::JointState)
+       (setq *top-selector-interval* 0.01)
+       (pushnew `(lambda () (send ,self :robot-interface-simulation-callback)) *timer-job*) ;; FIXME need to remove old one
+       (print *timer-job*)
        ))
    self)
   ;;
@@ -155,7 +182,7 @@
         #'(lambda (param)
             (let* ((controller-action (cdr (assoc :controller-action param)))
                    (action-type (cdr (assoc :action-type param)))
-                   (action (instance controller-action-client :init
+                   (action (instance controller-action-client :init self
                                      (if namespace (format nil "~A/~A" namespace controller-action)
                                        controller-action) action-type
                                        :groupname groupname)))
@@ -199,6 +226,29 @@
      tmp-actions
      ))
   ;;
+  (:robot-interface-simulation-callback ()
+   (let* ((joint-list (send robot :joint-list))
+          (all-joint-names (send-all joint-list :name)))
+     (send self :publish-joint-state)
+     ;(print (list 'actions controller-actions))
+     ;(print controller-type)
+     ;(print controller-table)
+     ;(maphash #'(lambda (x y)(print (list x y))) controller-table)
+     (dolist (param (send self controller-type)) ;; assuming all action is stored in controller-type (:default-controller)
+       ;(print (list 'p param))
+       (let* ((joint-names (cdr (assoc :joint-names param)))
+              (action-name (cdr (assoc :controller-action param)))
+              (action-client (find action-name controller-actions :key #'(lambda (x) (send x :name)) :test #'string=))
+              (av (send action-client :pop-angle-vector-simulation))
+              )
+         (when av
+           (dolist (j joint-names)
+             (if (find j all-joint-names :test #'string=)
+                 (let ((i (position j all-joint-names :test #'string=)))
+                   (send (elt joint-list i) :joint-angle (elt av i))))))
+         )) ;;
+     (if viewer (send self :draw-objects))
+     ))
   (:publish-joint-state ;; for simulation mode (joint-action-enable is nil)
    (&optional (joint-list (send robot :joint-list)))
    (let (msg names positions velocities efforts)
@@ -269,20 +319,8 @@
            (max max-time min-time))))))
   (:angle-vector-simulation
    (av tm ctype)
-   (let* ((prev-av (send robot :angle-vector))
-          (scale-av (send self :sub-angle-vector av prev-av))
-          (joint-names (flatten (mapcar #'(lambda (c) (cdr (assoc :joint-names c)))(send self ctype))))
-          (joint-ids (remove nil (mapcar #'(lambda (joint-name) (position joint-name (send robot :joint-list) :test #'(lambda (n j) (equal n (send j :name))))) joint-names)))
-          curr-av next-av)
-     (do ((curr-tm 0.0 (+ curr-tm 100.0)))
-         ((>= curr-tm tm))
-           (setq curr-av (send robot :angle-vector))
-           (setq next-av (v+ prev-av (scale (/ curr-tm tm) scale-av)))
-           (dolist (id joint-ids)
-             (setf (elt curr-av id) (elt next-av id)))
-	   (send robot :angle-vector curr-av)
-	   (send self :publish-joint-state)
-	   (if viewer (send self :draw-objects)))))
+   (let* ((prev-av (send robot :angle-vector)))
+     (send-all (gethash ctype controller-table) :push-angle-vector-simulation av tm prev-av)))
   (:angle-vector
    (av &optional (tm nil) (ctype controller-type) (start-time 0) &key (scale 1) (min-time 1.0))
    "Send joind angle to robot, this method retuns immediately, so use :wait-interpolation to block until the motion stops.
@@ -403,16 +441,17 @@
            (send self :angle-vector-simulation av tm ctype))
          ;;
          ;; update only joints with in current controller instaed of (send robot :angle-vector av)
-         (let* ((joint-names (flatten (mapcar #'(lambda (c) (cdr (assoc :joint-names c))) (send self ctype))))
+         (unless (send self :simulation-modep)
+           (let* ((joint-names (flatten (mapcar #'(lambda (c) (cdr (assoc :joint-names c))) (send self ctype))))
                 (joint-ids (mapcar #'(lambda (joint-name) (position joint-name (send robot :joint-list) :test #'(lambda (n j) (equal n (send j :name))))) joint-names)))
            (mapcar #'(lambda (name id)
                        (if (and (send robot :joint name) id (> (length av) id))
                            (send (send robot :joint name) :joint-angle (elt av id))
                          (warning-message 3 "[robot-interface.l] (angle-vector-sequence) could not find joint-name '~A' (~A) or joint-id ~A (av length ~A)~%" name (send robot :joint name) id (length av))))
-                   joint-names joint-ids))
-	 (when (send self :simulation-modep)
-	   (send self :publish-joint-state)
-	   (if viewer (send self :draw-objects)))
+                   joint-names joint-ids)))
+;	 (when (send self :simulation-modep)
+;	   (send self :publish-joint-state)
+;	   (if viewer (send self :draw-objects)))
          (push (list av
                      (copy-seq vel)  ;; velocities
                      (/ (+ st tm) 1000.0)) ;; tm + duration
@@ -437,7 +476,9 @@
 - ctype : controller to be wait
 - timeout : max time of for waiting"
    (when (send self :simulation-modep)
-     (return-from :wait-interpolation nil))
+     (while (some #'(lambda (a) (send a :interpolatingp)) controller-actions)
+       (send self :robot-interface-simulation-callback))
+     (return-from :wait-interpolation (send-all controller-actions :interpolatingp)))
    (cond
     (ctype
      (let ((cacts (gethash ctype controller-table)))

--- a/pr2eus/test/default-ri-test.l
+++ b/pr2eus/test/default-ri-test.l
@@ -26,13 +26,13 @@
 (deftest test-wait-interpolation
   (assert (send *robot* :reset-pose))
   (assert (send *ri* :angle-vector (send *robot* :angle-vector) 2000))
-  (assert (null (send *ri* :wait-interpolation)))
+  (assert (null (some #'identity (send *ri* :wait-interpolation))))
   )
 
 (deftest test-wait-interpolation-smooth
   (assert (send *robot* :reset-pose))
   (assert (send *ri* :angle-vector (send *robot* :angle-vector) 2000))
-  (assert (null (send *ri* :wait-interpolation-smooth 1000)))
+  (assert (null (some #'identity (send *ri* :wait-interpolation-smooth 1000))))
   )
 
 (deftest test-state
@@ -42,7 +42,7 @@
 (deftest test-potentio-vector
   (assert (send *robot* :reset-pose))
   (assert (send *ri* :angle-vector (send *robot* :angle-vector) 2000))
-  (assert (null (send *ri* :wait-interpolation)))
+  (assert (null (some #'identity (send *ri* :wait-interpolation))))
   (assert (< (norm (v- (send *robot* :angle-vector) (send *ri* :potentio-vector))) 10.0))
   )
 

--- a/pr2eus/test/pr2-ri-test-simple.l
+++ b/pr2eus/test/pr2-ri-test-simple.l
@@ -48,6 +48,19 @@
     (assert (eps= tm 1.0))
     ))
 
+;; https://github.com/jsk-ros-pkg/jsk_pr2eus/pull/165#discussion_r37421484
+(deftest test-go-pos
+  (let ()
+    (setq *ri* (instance pr2-interface :init))
+    (send *ri* :go-pos 1 0 0)
+    (send *ri* :go-pos 0 1 90)
+    (send *ri* :go-pos-no-wait -1 1 -90)
+    (send *ri* :go-wait)
+    (assert (eps-v= (send (send *ri* :worldcoords ) :worldpos) #f(0 0 0)))
+    ))
+
+
+;; https://github.com/jsk-ros-pkg/jsk_pr2eus/pull/143
 (defclass pr2-interface-wrong
   :super pr2-interface)
 (defmethod pr2-interface-wrong


### PR DESCRIPTION
- pr2-interface : support timer-based motion for :move-to
- test/default-ri-test.l: add test code for :wait-interpolation-smooth, #158
- more realistic simulation mode
-  pr2-interface.l: add :go-pos-unsafe, :go-pos-unsafe-no-wait,  :go-pos-unsafe-wait