### PR TITLE
Fix :move-to in sim mode (check frame-I'd) add test for :move-to

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,6 @@ matrix:
   allow_failures:
     # - env: ROS_DISTRO=groovy ROSWS=wstool BUILDER=catkin    USE_DEB=true
     # - env: ROS_DISTRO=groovy ROSWS=wstool BUILDER=catkin    USE_DEB=false
-    - env: ROS_DISTRO=indigo  ROSWS=wstool BUILDER=catkin   USE_DEB=true
     - env: ROS_DISTRO=indigo  ROSWS=wstool BUILDER=catkin   USE_DEB=false
     - env: ROS_DISTRO=hydro  ROSWS=wstool BUILDER=catkin    USE_DEB=false
 install:

--- a/pr2eus/pr2-interface.l
+++ b/pr2eus/pr2-interface.l
@@ -390,8 +390,11 @@
    (setq move-base-goal-msg (instance move_base_msgs::MoveBaseActionGoal :init))
    (setq move-base-goal-coords coords)
    (if (send self :simulation-modep)
-       (let ((orig-coords (send robot :copy-worldcoords)))
-         (setq current-goal-coords (send coords :transform robot :world)) ;; for simulation-callback
+       (let ()
+         (cond ((equal frame-id "/base_footprint")
+                (setq current-goal-coords (send coords :transform robot :world))) ;; for simulation-callback
+               (t
+                (setq current-goal-coords (send coords :copy-worldcoords)))) ;; for simulation-callback
          (return-from :move-to-send)))
    (let (ret (count 0) (tm (ros::time-now))
 	     (map-to-frame (send *tfl* :lookup-transform "/map" frame-id (ros::time 0))))

--- a/pr2eus/test/pr2-ri-test-simple.l
+++ b/pr2eus/test/pr2-ri-test-simple.l
@@ -52,10 +52,20 @@
 (deftest test-go-pos
   (let ()
     (setq *ri* (instance pr2-interface :init))
-    (send *ri* :go-pos 1 0 0)
+    (send *ri* :go-pos 1 0 0) ;; go-pos is relative to current position
     (send *ri* :go-pos 0 1 90)
     (send *ri* :go-pos-no-wait -1 1 -90)
     (send *ri* :go-wait)
+    (assert (eps-v= (send (send *ri* :worldcoords ) :worldpos) #f(0 0 0)))
+    ))
+
+(deftest test-move-to
+  (let ()
+    (setq *ri* (instance pr2-interface :init))
+    (send *ri* :move-to (make-coords :pos #f(1000 0 0))) ;; default is world and wait
+    (send *ri* :move-to (make-coords :pos #f(1000 1000 0) :rpy (float-vector pi/2 0 0)))
+    (send *ri* :move-to (make-coords) :no-wait t) ;; no-wait t means not wait so need to call wait
+    (send *ri* :move-to-wait) ;; wait move-to
     (assert (eps-v= (send (send *ri* :worldcoords ) :worldpos) #f(0 0 0)))
     ))
 


### PR DESCRIPTION
current implementation in simulationp is not correct, it always move to coordinates relative to current robot position, but that depends on `frame-id` arguments
https://github.com/jsk-ros-pkg/jsk_pr2eus/blob/d90a80e00a6aa03ad7fa632cf40551c13e2dc75b/pr2eus/pr2-interface.l#L394