### PR TITLE
[pr2eus/robot-interface.l, pr2eus/pr2-interface.l] fix: :wait-interpolation returns :interpolatingp on real robot

### DIFF
--- a/pr2eus/pr2-interface.l
+++ b/pr2eus/pr2-interface.l
@@ -113,24 +113,18 @@
   (:publish-joint-state () ;; overwrite for pr2
    (send-super :publish-joint-state (append (send robot :joint-list) (send robot :larm :gripper :joint-list) (send robot :rarm :gripper :joint-list))))
   ;;
-  (:wait-interpolation (&rest args);; overwrite for pr2, due to some joint is stll moving after joint-trajectry-action stops
+  (:wait-interpolation (&optional (ctype) (timeout 0)) ;; overwrite for pr2, due to some joint is stll moving after joint-trajectry-action stops
    (when (send self :simulation-modep) (return-from :wait-interpolation (send-super :wait-interpolation)))
-   (let (result)
-     (ros::ros-info "wait-interpolation debug: start")
-   ;;  (setq result (send-all controller-actions :wait-for-result))
-     ;;(setq result (send-super* :wait-interpolation args))
-     (dolist (ca controller-actions)
-       (push (send ca :wait-for-result) result))
-     (ros::ros-info "wait-interpolation debug: end")
-     (setq result (reverse result))
-	 (while (ros::ok)
-	   (send self :update-robot-state)
-	   (when (every #'(lambda(x)(< (abs (send x :joint-velocity))
-				       (if (derivedp x rotational-joint) 0.05 0.001)))
-			  (send robot :joint-list))
-		 (return)))
-	 result))
-
+   (ros::ros-info "wait-interpolation debug: start")
+   (send-super :wait-interpolation ctype timeout)
+   (ros::ros-info "wait-interpolation debug: end")
+   (while (ros::ok)
+    (send self :update-robot-state)
+     (when (every #'(lambda(x)(< (abs (send x :joint-velocity))
+                                 (if (derivedp x rotational-joint) 0.05 0.001)))
+                  (send robot :joint-list))
+       (return)))
+   (send-super :wait-interpolatingp ctype))
   ;;
   ;;
   (:larm-controller

--- a/pr2eus/pr2-interface.l
+++ b/pr2eus/pr2-interface.l
@@ -124,7 +124,7 @@
                                  (if (derivedp x rotational-joint) 0.05 0.001)))
                   (send robot :joint-list))
        (return)))
-   (send-super :wait-interpolatingp ctype))
+   (send-all controller-actions :interpolatingp))
   ;;
   ;;
   (:larm-controller

--- a/pr2eus/robot-interface.l
+++ b/pr2eus/robot-interface.l
@@ -476,15 +476,15 @@
 - ctype : controller to be wait
 - timeout : max time of for waiting
 - return values is a list of interpolatingp for all controllers, so (null (some #'identity (send *ri* :wait-interpolation))) -> t if all interpolation has stopped"
-   (when (send self :simulation-modep)
-     (while (some #'(lambda (a) (send a :interpolatingp)) controller-actions)
-       (send self :robot-interface-simulation-callback))
-     (return-from :wait-interpolation (send-all controller-actions :interpolatingp)))
-   (cond
-    (ctype
-     (let ((cacts (gethash ctype controller-table)))
-       (send-all cacts :wait-for-result :timeout timeout)))
-    (t (send-all controller-actions :wait-for-result :timeout timeout))))
+   (if (send self :simulation-modep)
+       (while (some #'(lambda (a) (send a :interpolatingp)) controller-actions)
+              (send self :robot-interface-simulation-callback))
+       (cond ;; real robot
+         (ctype
+          (let ((cacts (gethash ctype controller-table)))
+            (send-all cacts :wait-for-result :timeout timeout)))
+         (t (send-all controller-actions :wait-for-result :timeout timeout))))
+   (send-all controller-actions :interpolatingp))
   (:interpolatingp (&optional (ctype)) ;; controller-type ;; check someone is moving
 "Check if the last sent motion is executing
 return t if interpolating"


### PR DESCRIPTION
**NOTICE**
This PR changes return value of `:wait-interpolation`

**SUMMARY**
the return value of `:wait-interpolation` is defined in docs as below:

> return values is a list of interpolatingp for all controllers, so (null (some #'identity (send *ri* :wait-interpolation))) -> t if all interpolation has stopped

but on real robot it returns `(send-all controller-actions :wait-for-result))`
So I fixed according with docs.

tested on pr2-simulator and pr1012 real robot.

discussed at https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/187
