### PR TITLE
Add method to define limb-controller parameters

### DIFF
--- a/pr2eus/robot-interface.l
+++ b/pr2eus/robot-interface.l
@@ -1051,6 +1051,25 @@ Return value is a list of interpolatingp for all controllers, so (null (some #'i
     )
    (warn ";; Stop Euslisp mannequin mode.~%")
    )
+  ;; Method for define limb controller method using defmethod
+  ;; If debugp t, we can see defmethod s-expressions.
+  (:def-limb-controller-method
+   (limb &key (debugp nil))
+   (let ((sexp `(defmethod ,(send (class self):name)
+                  (,(read-from-string (format nil "~A-controller" limb))
+                   ()
+                   (list
+                    (list
+                     (cons :group-name ,(string-downcase limb))
+                     (cons :controller-action ,(format nil "~A_controller/joint_trajectory_action" (string-downcase limb)))
+                     (cons :controller-state ,(format nil "~A_controller/state" (string-downcase limb)))
+                     (cons :action-type pr2_controllers_msgs::JointTrajectoryAction)
+                     (cons :joint-names (list ,@(send-all (send robot limb :links) :name))))
+                    )))))
+     (if debugp
+         (pprint (macroexpand sexp)))
+     (eval sexp)
+     ))
   )
 ;;
 (defclass ros-interface


### PR DESCRIPTION
This is related with https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/64.

In this PR, I added a method to define limb controller.
Without this, we need to write limb controller definition one by one:
https://github.com/start-jsk/rtmros_tutorials/blob/master/hrpsys_ros_bridge_tutorials/euslisp/hrp2jsknt-interface.l#L21
https://github.com/start-jsk/rtmros_tutorials/blob/master/hrpsys_ros_bridge_tutorials/euslisp/jaxon-interface.l#L65

After this PR, we need to write the following codes in `:init-ending`.
```
(dolist (limb '(:rleg :lleg :rarm :larm)) (send self :def-limb-controller-method limb))
```

In this method, some macro codes are written.
Because sometimes Euslisp macro codes are hard to be read and hard to be maintained, 
I added `debugp` argument to print `macroexpand` results.
```
$ (send *ri* :def-limb-controller-method :torso :debugp t)
(defmethod
   jaxon_red-interface
   (:torso-controller
    nil
    (list
       (list
          (cons :group-name "torso")
          (cons
             :controller-action
             "torso_controller/joint_trajectory_action")
          (cons :controller-state "torso_controller/state")
          (cons :action-type pr2_controllers_msgs::jointtrajectoryaction)
          (cons :joint-names (list "CHEST_LINK0" "CHEST_LINK1" "CHEST_LINK2"))))))
```

@YoheiKakiuchi , Please review this.