### PR TITLE
Revert https://github.com/jsk-ros-pkg/jsk_pr2eus/pull/188 and fix :torque-vector to return joint torques.

### DIFF
--- a/pr2eus/robot-interface.l
+++ b/pr2eus/robot-interface.l
@@ -535,7 +535,10 @@ Return value is a list of interpolatingp for all controllers, so (null (some #'i
    t)
   ;;
   (:worldcoords () "Returns world coords of robot, This method uses caced data" (send robot :copy-worldcoords))
-  (:torque-vector () "Return torque vector of robot, This method uses caced data" (send robot :torque-vector))
+  (:torque-vector
+   ()
+   "Return torque vector of robot, This method uses caced data"
+   (coerce (send-all (send robot :joint-list) :joint-torque) float-vector))
   (:potentio-vector () "Retuns current robot angle vector, This method uses caced data" (send robot :angle-vector))
   (:reference-vector () "Return reference joint angle vector, This method uread current state." (send self :state-vector :desired))
   (:actual-vector () "Returns current robot angle vector, This method read curren tstate." (send self :state-vector :actual))
@@ -736,10 +739,7 @@ Return value is a list of interpolatingp for all controllers, so (null (some #'i
      ((:potentio-vector :angle-vector)
       (send robot :angle-vector))
      (:torque-vector
-      (send robot :torque-vector))
-     (:effort-vector
-      (map float-vector #'(lambda (j) (send j :joint-torque))
-           (send robot :joint-list)))
+      (send self :torque-vector))
      (:worldcoords
       (send *tfl* :lookup-transform (or (cadr args) "/map") "/base_footprint" (ros::time)))
      (t


### PR DESCRIPTION
https://github.com/jsk-ros-pkg/jsk_pr2eus/pull/188
はまだ途中だったのですがmergeされてしまったので、
以下で修正しました。

`:state`系の`:torque-vector`をよんだときに、逆動力学計算せず
torque-vectorをもってくるようになります。
upstream側は、影響する範囲を調べて直して、、、がまだかかりそうです
https://github.com/euslisp/jskeus/issues/94

@YoheiKakiuchi , @garaemon 
確認してもらえると助かります。