### PR TITLE
clear-costmap for custom move_base node name

### DIFF
--- a/pr2eus/robot-interface.l
+++ b/pr2eus/robot-interface.l
@@ -1659,17 +1659,21 @@ send-action [ send message to action server, it means robot will move ]"
 ;; navigation-client.l
 ;;
 
-;; reset local costmap and clear unknown grid around robot
-(defun clear-costmap ()
-  (call-empty-service "/move_base_node/clear_costmaps"))
+(defun clear-costmap (&key (node-name "/move_base_node"))
+  "reset local costmap and clear unknown grid around robot"
+  (call-empty-service (format nil "/~A/clear_costmaps" node-name)))
 
-;; change inflation range of local costmap
-(defun change-inflation-range (&optional (range 0.2))
+(defun change-inflation-range (&optional (range 0.2)
+                                         &key (node-name "/move_base_node")
+                                              (costmap-name "local_costmap")
+                                              (inflation-name "inflation")
+                                         )
+  "change inflation range of local costmap"
   (let ((req (instance dynamic_reconfigure::ReconfigureRequest :init)))
     (send req :config :doubles
-	  (list (instance dynamic_reconfigure::DoubleParameter :init
-			  :name "inflation_radius" :value range)))
-    (ros::service-call "/move_base_node/local_costmap/inflation/set_parameters" req)
+          (list (instance dynamic_reconfigure::DoubleParameter :init
+                          :name "inflation_radius" :value range)))
+    (ros::service-call (format nil "~A/~A/~A/set_parameters" node-name costmap-name inflation-name) req)
     ))
 
 (provide :robot-interface "robot-interface.l")


### PR DESCRIPTION
- robot-interface.l: fix clear-costmap/change-inflation-range to support different move_base node name