### PR TITLE
robot-interface.l : add option to set queue size for /joint_state subscriber

### DIFF
--- a/pr2eus/robot-interface.l
+++ b/pr2eus/robot-interface.l
@@ -109,7 +109,7 @@
 - namespace : ros nodehandle name space
 - joint-states-topic jst : name for subscribing joint state topic
 - joint-states-queue-size : queue size of joint state topic. if you have two different node publishing joint_state, better to use 2. default is 1
-- publish-joint-state-topic :  name for publishing joint state topuc (only for simulation)
+- publish-joint-state-topic :  name for publishing joint state topic (only for simulation)
 - conter-timeout : timeout seconds for controller lookup
 - visualizatoin-marker-topic : topic name for visualize
 "

--- a/pr2eus/robot-interface.l
+++ b/pr2eus/robot-interface.l
@@ -94,6 +94,7 @@
    (&rest args &key ((:robot r)) ((:objects objs)) (type :default-controller)
           (use-tf2) ((:groupname nh) "robot_multi_queue") ((:namespace ns))
           ((:joint-states-topic jst) "joint_states")
+          ((:joint-states-queue-size jsq) 1)
           ((:publish-joint-states-topic pjst) nil)
           ((:controller-timeout ct) 3)
           ((:visuzlization-marker-topic vmt) "robot_interface_marker_array")
@@ -106,6 +107,8 @@
 - use-tf2 : use tf2
 - groupname : ros nodehandle group name
 - namespace : ros nodehandle name space
+- joint-states-topic jst : name for subscribing joint state topic
+- joint-states-queue-size : queue size of joint state topic. if you have two different node publishing joint_state, better to use 2. default is 1
 - publish-joint-state-topic :  name for publishing joint state topuc (only for simulation)
 - conter-timeout : timeout seconds for controller lookup
 - visualizatoin-marker-topic : topic name for visualize
@@ -155,7 +158,7 @@
 
    (ros::subscribe (if namespace (format nil "~A/~A" namespace joint-states-topic)
                      joint-states-topic) sensor_msgs::JointState
-                   #'send self :ros-state-callback :groupname groupname)
+                   #'send self :ros-state-callback jsq :groupname groupname)
    ;;
    (setq controller-table (make-hash-table :size 14 :test #'eq :rehash-size 1.2))
    (setq controller-type type)


### PR DESCRIPTION
This probrem is reported on Baxter robot with custom gripper hand, which had two different node publishing `joint_states`

- realtime_loop for baxter joints ~100 hz
- gripper node for girpper joint ~10 hz

Since we set queue size of `joint_states` as 1, and when ever we call `send *ri* :state` (or `:spin-once`) it may fail to get baxter joints.
From our experiments, when we run our main loop at 10hz, usually `:state` read data from `realtime_loop`, but at some point it reads gripper node for several sequences
```
(ros-state-call-back seq 52764151 stamp #<ros::time #X1c4fcb70 1464165319.524> position #f(0.0 -2.52686 -94.5264 134.626 97.4268 -2.39502 91.3843 10.2393 0.0 104.546 68.9062 -19.5996 48.7793 -71.5649 -14.1724 -66.2915))
(ros-state-call-back seq 52764161 stamp #<ros::time #X2074fc48 1464165319.624> position #f(0.0 -2.50488 -94.5264 134.736 97.5146 -2.39502 91.3843 10.2393 0.0 105.161 69.082 -19.5557 49.0869 -71.1475 -13.9526 -67.3022))
(ros-state-call-back seq 52764171 stamp #<ros::time #X20706868 1464165319.724> position #f(0.0 -2.52686 -94.5264 134.692 97.5146 -2.39502 91.4062 10.2393 0.065918 105.688 69.1479 -19.5776 49.3726 -70.8618 -13.623 -68.0713))
(ros-state-call-back seq 52764181 stamp #<ros::time #X2069d400 1464165319.824> position #f(0.0 -2.52686 -94.4824 134.692 97.4487 -2.37305 91.3623 10.2393 0.0 106.238 69.1479 -19.5996 49.7241 -70.4224 -13.3594 -69.0381))
(ros-state-call-back seq 52764191 stamp #<ros::time #X20b3e360 1464165319.924> position #f(0.0 -2.52686 -94.5264 134.714 97.4707 -2.39502 91.3843 10.2832 0.0 106.721 69.3018 -19.6436 50.0317 -70.0928 -13.2935 -69.873))
(ros-state-call-back seq 161677 stamp #<ros::time #X20adf998 1464165320.028> position #f(89.9999))
(ros-state-call-back seq 161678 stamp #<ros::time #X20ab2200 1464165320.129> position #f(89.9999))
(ros-state-call-back seq 161679 stamp #<ros::time #X20a6c9a8 1464165320.231> position #f(89.9999))
(ros-state-call-back seq 161680 stamp #<ros::time #X20fcdb50 1464165320.332> position #f(89.9999))
(ros-state-call-back seq 161681 stamp #<ros::time #X20f882f8 1464165320.432> position #f(89.9999))
(ros-state-call-back seq 161682 stamp #<ros::time #X20f5ab60 1464165320.533> position #f(89.9999))
(ros-state-call-back seq 161683 stamp #<ros::time #X20f152f0 1464165320.634> position #f(89.9999))
(ros-state-call-back seq 161684 stamp #<ros::time #X20ed4910 1464165320.735> position #f(89.9999))
(ros-state-call-back seq 161685 stamp #<ros::time #X210ceb70 1464165320.836> position #f(89.9999))
(ros-state-call-back seq 161686 stamp #<ros::time #X21080f18 1464165320.938> position #f(89.9999))
(ros-state-call-back seq 52764301 stamp #<ros::time #X2105bb50 1464165321.023> position #f(0.0 -2.52686 -94.5044 134.714 97.5146 -2.43896 91.3843 10.0635 0.021973 112.566 71.1475 -19.7974 53.2837 -66.2036 -10.3711 -79.6509))
(ros-state-call-back seq 52764311 stamp #<ros::time #X21005930 1464165321.124> position #f(0.0 -2.52686 -94.5703 134.648 97.4927 -2.43896 91.4282 9.93164 -0.021973 113.049 71.3232 -19.8193 53.6353 -65.6763 -10.1953 -80.4419))
(ros-state-call-back seq 52764321 stamp #<ros::time #X2154c198 1464165321.223> position #f(0.0 -2.52686 -94.4824 134.736 97.4268 -2.41699 91.4062 9.97559 0.021973 113.577 71.4551 -19.7754 53.9868 -65.3687 -10.1514 -81.2988))
(ros-state-call-back seq 52764331 stamp #<ros::time #X214f8af8 1464165321.323> position #f(0.0 -2.52686 -94.5264 134.692 97.4487 -2.37305 91.3843 9.97559 0.021973 114.038 71.521 -19.8413 54.2725 -65.2588 -10.1514 -82.0898))
(ros-state-call-back seq 52764341 stamp #<ros::time #X214b0ed0 1464165321.423> position #f(0.0 -2.52686 -94.5044 134.692 97.4707 -2.37305 91.4062 9.82178 0.021973 114.521 71.6748 -19.8853 54.6021 -64.7754 -9.90967 -82.771))
(ros-state-call-back seq 52764351 stamp #<ros::time #X11d23b88 1464165321.523> position #f(0.0 -2.54883 -94.5264 134.736 97.5146 -2.39502 91.3843 9.82178 0.0 115.027 71.7847 -19.9292 54.9097 -64.314 -9.4043 -83.5181))
(ros-state-call-back seq 52764361 stamp #<ros::time #X11cecf70 1464165321.623> position #f(0.0 -2.50488 -94.5703 134.692 97.4927 -2.37305 91.3843 9.82178 -0.021973 115.422 71.8945 -19.9512 55.0854 -64.314 -9.11865 -84.1553))
(ros-state-call-back seq 52764371 stamp #<ros::time #X11c8ba70 1464165321.723> position #f(0.0 -2.52686 -94.5483 134.692 97.4707 -2.39502 91.3623 9.75586 -0.021973 115.862 72.1143 -19.9731 55.3052 -64.0063 -9.11865 -84.8364))
(ros-state-call-back seq 52764381 stamp #<ros::time #X11c54e58 1464165321.823> position #f(0.0 -2.50488 -94.5703 134.648 97.4707 -2.41699 91.3843 9.75586 -0.021973 116.235 72.1362 -19.9512 55.5029 -63.501 -9.07471 -85.4736))

```
In this case, when we call `send *ri* :state :potentio-vector`, it may get robot posture of 1-2 sec before.

By setting 2 as the queue size, the output becomes
```
(ros-state-call-back seq 52751618 stamp #<ros::time #X20b04140 1464165194.193> #f(0.0 -2.54883 -94.5264 134.561 97.4268 -2.39502 91.4282 9.68994 0.0 92.2192 64.6875 -20.0171 41.1987 -80.376 -21.4453 -46.0767))
(ros-state-call-back seq 52751619 stamp #<ros::time #X20ae66f8 1464165194.203> #f(0.0 -2.52686 -94.5264 134.604 97.4268 -2.37305 91.3843 9.68994 0.021973 92.2192 64.7314 -20.0171 41.1987 -80.3979 -21.4453 -46.0986))
(ros-state-call-back seq 52751628 stamp #<ros::time #X20ac3748 1464165194.293> #f(0.0 -2.54883 -94.5703 134.648 97.4707 -2.37305 91.4062 9.71191 0.0 92.1973 64.6875 -19.9731 41.2207 -80.4639 -21.4673 -46.1206))
(ros-state-call-back seq 52751629 stamp #<ros::time #X20aa5550 1464165194.303> #f(0.0 -2.52686 -94.5264 134.648 97.4707 -2.39502 91.3843 9.71191 0.0 92.1973 64.7095 -19.9731 41.2207 -80.3979 -21.4233 -46.0986))
(ros-state-call-back seq 52751638 stamp #<ros::time #X20a84d18 1464165194.393> #f(0.0 -2.50488 -94.5483 134.561 97.4048 -2.39502 91.4062 9.68994 0.0 92.1973 64.6436 -20.0171 41.1987 -80.3979 -21.4233 -46.0767))
(ros-state-call-back seq 52751639 stamp #<ros::time #X20a672d0 1464165194.403> #f(0.0 -2.54883 -94.5264 134.626 97.4268 -2.41699 91.4062 9.68994 0.021973 92.2632 64.6875 -20.0171 41.2207 -80.376 -21.4673 -46.0986))
(ros-state-call-back seq 160435 stamp #<ros::time #X20a44260 1464165194.497> #f(89.9999))
(ros-state-call-back seq 52751649 stamp #<ros::time #X20a41170 1464165194.503> #f(0.0 -2.54883 -94.5703 134.67 97.4927 -2.35107 91.3623 9.75586 0.0 92.1973 64.7095 -19.9951 41.2207 -80.3979 -21.4453 -46.1206))
(ros-state-call-back seq 160436 stamp #<ros::time #X20a20248 1464165194.598> #f(89.9999))
(ros-state-call-back seq 52751659 stamp #<ros::time #X20a16f48 1464165194.603> #f(0.0 -2.52686 -94.5264 134.692 97.4707 -2.41699 91.3843 9.71191 0.043945 92.2192 64.6436 -19.9951 41.2427 -80.3979 -21.4453 -46.0986))
(ros-state-call-back seq 160437 stamp #<ros::time #X209f3cc8 1464165194.699> #f(89.9999))
(ros-state-call-back seq 52751669 stamp #<ros::time #X209f0b48 1464165194.703> #f(0.0 -2.50488 -94.5703 134.67 97.4927 -2.39502 91.4062 9.77783 -0.043945 92.2192 64.7095 -20.0171 41.1987 -80.4199 -21.4014 -46.1206))
(ros-state-call-back seq 160438 stamp #<ros::time #X209cfdb8 1464165194.800> #f(89.9999))
(ros-state-call-back seq 52751679 stamp #<ros::time #X209cce60 1464165194.803> #f(0.0 -2.52686 -94.5264 134.626 97.4707 -2.39502 91.4062 9.73389 0.043945 92.2412 64.6655 -20.0391 41.2207 -80.4419 -21.4453 -46.0547))
(ros-state-call-back seq 160439 stamp #<ros::time #X20f31ef0 1464165194.902> #f(89.9999))
(ros-state-call-back seq 52751689 stamp #<ros::time #X20f2ec50 1464165194.903> #f(0.0 -2.50488 -94.5483 134.692 97.5366 -2.39502 91.4062 9.75586 -0.021973 92.2192 64.6655 -19.9951 41.2207 -80.4199 -21.4453 -46.0986))
(ros-state-call-back seq 160440 stamp #<ros::time #X20f0e2e0 1464165195.003> #f(89.9999))
(ros-state-call-back seq 52751699 stamp #<ros::time #X20f0b4a8 1464165195.003> #f(0.0 -2.54883 -94.4824 134.626 97.4707 -2.35107 91.3843 9.71191 0.021973 92.1973 64.6436 -20.0391 41.2207 -80.4199 -21.4233 -46.1206))
(ros-state-call-back seq 160441 stamp #<ros::time #X20ee8138 1464165195.103> #f(89.9999))
```
this will get robot posture at least 0.1 sec beefore


Same issue was seen on HRP2 robot with @mmurooka