### PR TITLE
[pr2eus/CMakeLists.txt] remove unused variable from catkin_package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,8 @@ env:
     #- ROS_DISTRO=groovy ROSWS=rosws  BUILDER=rosbuild  USE_DEB=false
     # - ROS_DISTRO=groovy ROSWS=wstool BUILDER=catkin    USE_DEB=true
     # - ROS_DISTRO=groovy ROSWS=wstool BUILDER=catkin    USE_DEB=false
-    - ROS_DISTRO=hydro  ROSWS=wstool BUILDER=catkin    USE_DEB=true
-    - ROS_DISTRO=hydro  ROSWS=wstool BUILDER=catkin    USE_DEB=false
+    - ROS_DISTRO=hydro  ROSWS=wstool BUILDER=catkin    USE_DEB=true CATKIN_TOOLS_BUILD_OPTIONS="-iv --summarize --no-status"
+    - ROS_DISTRO=hydro  ROSWS=wstool BUILDER=catkin    USE_DEB=false CATKIN_TOOLS_BUILD_OPTIONS="-iv --summarize --no-status"
     - ROS_DISTRO=indigo  ROSWS=wstool BUILDER=catkin   USE_DEB=true
     - ROS_DISTRO=indigo  ROSWS=wstool BUILDER=catkin   USE_DEB=false
 matrix:
@@ -29,7 +29,7 @@ matrix:
     # - env: ROS_DISTRO=groovy ROSWS=wstool BUILDER=catkin    USE_DEB=true
     # - env: ROS_DISTRO=groovy ROSWS=wstool BUILDER=catkin    USE_DEB=false
     - env: ROS_DISTRO=indigo  ROSWS=wstool BUILDER=catkin   USE_DEB=false
-    - env: ROS_DISTRO=hydro  ROSWS=wstool BUILDER=catkin    USE_DEB=false
+    - env: ROS_DISTRO=hydro  ROSWS=wstool BUILDER=catkin    USE_DEB=false CATKIN_TOOLS_BUILD_OPTIONS="-iv --summarize --no-status"
 install:
   - if [ $ROS_DISTRO = groovy ]; then sudo apt-get install -qq -y ros-$ROS_DISTRO-audio-common ros-$ROS_DISTRO-navigation ros-$ROS_DISTRO-pr2-common ros-$ROS_DISTRO-pr2-controllers; fi
 script: source .travis/travis.sh

--- a/pr2eus/CMakeLists.txt
+++ b/pr2eus/CMakeLists.txt
@@ -6,12 +6,7 @@ find_package(catkin REQUIRED COMPONENTS euscollada control_msgs nav_msgs dynamic
   )
 
 
-catkin_package(
-    DEPENDS 
-    CATKIN-DEPENDS 
-    INCLUDE_DIRS 
-    LIBRARIES 
-)
+catkin_package()
 
 install(DIRECTORY test
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}


### PR DESCRIPTION
Latest `catkin_tools` has become to consider arguments of `catkin_package` in `CMakeLists.txt`.

build of `jsk_roseus` fails with error on this package.

```bash
[pr2eus] WARNING: Package "ompl" does not follow the version conventions. It should not contain leading zeros (unless the number is 0).
[pr2eus] WARNING: Package "ompl" does not follow the version conventions. It should not contain leading zeros (unless the number is 0).
[pr2eus] -- [roseus.cmake] pr2eus depends on audio_common_msgs;std_msgs;actionlib_msgs;diagnostic_msgs;geometry_msgs;nav_msgs;pr2_msgs;rosgraph_msgs;roscpp;actionlib;actionlib_tutorials;dynamic_reconfigure;move_base_msgs;sensor_msgs;shape_msgs;sound_play;std_srvs;tf;tf2_msgs;topic_tools;trajectory_msgs;control_msgs;pr2_controllers_msgs;visualization_msgs
[pr2eus] -- [roseus.cmake] pr2eus will compile audio_common_msgs;diagnostic_msgs;nav_msgs;pr2_msgs;move_base_msgs;shape_msgs;sound_play;trajectory_msgs;control_msgs;pr2_controllers_msgs;pr2eus
[pr2eus] CMake Error at /opt/ros/hydro/share/catkin/cmake/catkin_package.cmake:163 (message):
[pr2eus]   catkin_package() DEPENDS on 'CATKIN-DEPENDS' which must be
[pr2eus]   find_package()-ed before.  If it is a catkin package it can be declared as
[pr2eus]   CATKIN_DEPENDS instead without find_package()-ing it.
[pr2eus] Call Stack (most recent call first):
[pr2eus]   /opt/ros/hydro/share/catkin/cmake/catkin_package.cmake:102 (_catkin_package)
[pr2eus]   CMakeLists.txt:9 (catkin_package)
[pr2eus] 
[pr2eus] 
[pr2eus] -- Configuring incomplete, errors occurred!
[pr2eus] <== '/home/travis/ros/ws_jsk_roseus/build/pr2eus/build_env.sh /usr/bin/cmake /home/travis/ros/ws_jsk_roseus/src/jsk_pr2eus/pr2eus -DCATKIN_DEVEL_PREFIX=/home/travis/ros/ws_jsk_roseus/devel -
```