### PR TITLE
[pr2eus/speak.l] add *speak-timeout* param to wait action server

### DIFF
--- a/pr2eus/speak.l
+++ b/pr2eus/speak.l
@@ -5,9 +5,10 @@
 
 (defparameter *speak-wait* nil)
 (defparameter *speak-action-clients* (make-hash-table))
+(defparameter *speak-timeout* 20)
 
 (defun send-speak-msg (msg
-                       &key (topic-name "robotsound") (timeout 0)
+                       &key (topic-name "robotsound") (timeout *speak-timeout*)
                             (wait *speak-wait*))
   (cond
     ((boundp 'sound_play::soundrequestaction)
@@ -32,7 +33,7 @@
       (ros::publish topic-name msg)
       t)))
 
-(defun speak-google (str &key (lang :ja) (wait *speak-wait*) (topic-name "robotsound") (timeout 20))
+(defun speak-google (str &key (lang :ja) (wait *speak-wait*) (topic-name "robotsound") (timeout *speak-timeout*))
   (let* ((qstr (escaped-url-string-from-namestring
                 (concatenate string
                              "http://translate.google.com/translate_tts?tl="
@@ -47,7 +48,7 @@
                     :wait wait
                     :timeout timeout)))
 
-(defun speak-jp (str &key google (wait *speak-wait*) (topic-name "robotsound_jp") (timeout 20))
+(defun speak-jp (str &key google (wait *speak-wait*) (topic-name "robotsound_jp") (timeout *speak-timeout*))
   (when google
       (return-from speak-jp
         (speak-google str :lang :ja :wait wait :timeout timeout)))
@@ -61,7 +62,7 @@
    :wait wait
    :timeout timeout))
 
-(defun speak-en (str &key google (wait *speak-wait*) (topic-name "robotsound") (timeout 20))
+(defun speak-en (str &key google (wait *speak-wait*) (topic-name "robotsound") (timeout *speak-timeout*))
   (when google
     (return-from speak-en
             (speak-google str :lang :en :wait wait :timeout timeout)))


### PR DESCRIPTION
In eus test environment, sound play action server does not exists.
In this case timeout must be small not to wait action server.