### PR TITLE
[pr2eus/robot-interface.l] update actionlib name of default controller.

### DIFF
--- a/pr2eus/robot-interface.l
+++ b/pr2eus/robot-interface.l
@@ -793,7 +793,7 @@ Return value is a list of interpolatingp for all controllers, so (null (some #'i
    ()
    (list
     (list
-     (cons :controller-action "fullbody_controller/joint_trajectory_action")
+     (cons :controller-action "fullbody_controller/follow_joint_trajectory_action")
      (cons :controller-state "fullbody_controller/state")
      (cons :action-type control_msgs::FollowJointTrajectoryAction)
      (cons :joint-names (mapcar #'(lambda (n) (if (symbolp n) (symbol-name n) n)) (send-all (send robot :joint-list) :name))))))


### PR DESCRIPTION
related to https://github.com/jsk-ros-pkg/jsk_pr2eus/pull/237#issuecomment-253728720 and https://github.com/start-jsk/rtmros_common/pull/970#issuecomment-253446024.

one of this PR or https://github.com/start-jsk/rtmros_common/pull/970 should be merged.


check result of whether hrp2jsk-init works or not:
- pr2eus (latest origin/master), hrpsys_ros_bridge (latest origin/master): not work
- pr2eus (This PR), hrpsys_ros_bridge (latest origin/master): work
- pr2eus (latest origin/master), hrpsys_ros_bridge (https://github.com/start-jsk/rtmros_common/pull/970) work