### PR TITLE
[pr2-interface.l] grasp object even if no collision with gripper

### DIFF
--- a/pr2eus/pr2-interface.l
+++ b/pr2eus/pr2-interface.l
@@ -231,7 +231,7 @@ Example: (send self :gripper :rarm :position) => 0.00"
           (format nil "~A-~A" (string (car args)) (string (cadr args)))
           *keyword-package*)))
   (:start-grasp
-   (&optional (arm :arms) &key ((:gain g) 0.01) ((:objects objs) objects))
+   (&optional (arm :arms) &key ((:gain g) 0.01) ((:objects objs) objects) force-assoc)
    (send self :move-gripper arm 0.0 :effort (* 2000 g) :wait t)
    (unless joint-action-enable
      (dolist (a (if (eq arm :arms) '(:larm :rarm) (list arm)))
@@ -244,8 +244,9 @@ Example: (send self :gripper :rarm :position) => 0.00"
 		     (send-all (send l :bodies) :vertices))
 		 (send robot a :gripper :links))))))
 	 (dolist (obj objs)
-	   (when (and (find-method obj :faces)
-		      (not (= (pqp-collision-check grasp-convex obj) 0)))
+	   (when (or force-assoc
+               (and (find-method obj :faces)
+                    (not (= (pqp-collision-check grasp-convex obj) 0))))
 	     (if (send obj :parent) (send (send obj :parent) :dissoc obj))
 	     (send robot a :end-coords :assoc obj)))))
      ;; (send self :update-robot-state) ;; update state of 'robot' for real robot


### PR DESCRIPTION
In current implementation, if no object is touched with gripper, the object is not get `:assoc`.

**BEFORE**

```lisp
(load "models/room73b2-mug-cup-object.l")
(load "package://pr2eus/pr2-interface.l")
(pr2-init)
(setq cup (room73b2-mug-cup))
(send cup :translate #f(700 0 900))
(send cup :rotate pi/2 :z)
(objects (list cup *pr2*))
(send *ri* :objects (list cup))
(send *ri* :stop-grasp :rarm)
(seond *pr2* :rarm :inverse-kinematics (car (send cup :handle)))
(send *ri* :start-grasp :objects (send *ri* :find-object cup))
(send *ri* :robot :rarm :end-coords :descendants) ;; => returns nil, because cup handle is not touched gripper surface
```

**AFTER**

- assoc object if gripper is closed
- print warning if no object is touched.

```lisp
;; same as above
(send *ri* :start-grasp :objects (send *ri* :find-object cup))
[ WARN] [1478083431.566305169]: no collision occurred between gripper and object room73b2-mug-cup
(send *ri* :robot :rarm :end-coords :descendants) ;; => (#<room73b2-mug-cup-object #X5f9d220 room73b2-mug-cup  700.0 1.137e-13 900.0 / 1.571 -1.570e-16 -3.140e-16>)
```