### PR TITLE
Add speak-en-jp to switch language by speak_language rosparam and add test codes.

### DIFF
--- a/pr2eus/speak.l
+++ b/pr2eus/speak.l
@@ -75,4 +75,39 @@
    :wait wait
    :timeout timeout))
 
+(defun speak
+  (speach-string-candidates
+   &rest args)
+  "Speak with language selection.
+   Argument:
+     speach-string-candidates should be two types:
+       List of cons of language name and speak-string. For example, '( (\"en\" . \"Hello\") (\"jp\" . \"こんにちわ\") )
+       English speak-string. For example, \"Hello\", which is same as '( (\"en\" . \"Hello\") ).
+     If adequate argument are not specified, english string are input to speak-google.
+   Speak language name:
+     Speak language name is switched by 'speak_language' rosparam.
+     If no such rosparam is specified, speak \"en\".
+     If users do not use speak-google, speak_language should be related with speak-xx functinos, such as speak-jp and speak-en. Otherwise, speak function invokes error."
+  ;; Convert atom argument to candidate list
+  (if (stringp speach-string-candidates)
+      (setq speach-string-candidates (list (cons "en" speach-string-candidates))))
+  ;; Check speak_language
+  (let* ((lang (or (ros::get-param "speak_language") "en"))
+         (speak-string (cdr (assoc lang speach-string-candidates :test #'string=)))
+         (speak-func
+          (if (fboundp (eval (read-from-string (format nil "'speak-~A" lang))))
+              (eval (read-from-string (format nil "#'speak-~A" lang))))))
+    ;; Check argument
+    (unless speak-string
+      (warn ";; No speach string are specified for ~A from argumenta!! Use english and speak-google!!~%" lang)
+      (setq speak-string (cdr (assoc "en" speach-string-candidates :test #'string=)))
+      (setq speak-func #'speak-google))
+    ;; Check speak-xx function existence.
+    (unless speak-func
+      (error ";; No such speak function (speak-~A) defined!!~%" lang))
+    (warn ";; ~A~%" (list (cadr speak-func) speak-string args))
+    ;; Speak
+    (apply speak-func speak-string args)
+    ))
+
 (provide :speak) ;; end of speak.l

--- a/pr2eus/test/speak-test.l
+++ b/pr2eus/test/speak-test.l
@@ -21,6 +21,20 @@
 (deftest test-speak-google ()
   (assert (speak-google "bonjour" :timeout 10 :lang :fr)))
 
+(deftest test-speak-en-jp ()
+  (labels ((test-speak
+            ()
+            (and (speak '(("en" . "hello, world") ("jp" . "こんにちは")) :timeout 10)
+            ;;   (speak '(("en" . "hello, world") ("jp" . "こんにちは")) :wait t :debug t)
+                 (speak '(("en" . "hello, world") ("jp" . "こんにちは")) :timeout 10 :google t)
+                 (speak '(("en" . "hello, world")) :timeout 10)
+                 (speak "hello, world" :timeout 10)
+                 )))
+    (assert (progn (test-speak)))
+    (assert (progn (ros::set-param "speak_language" "jp") (test-speak)))
+    (assert (progn (ros::set-param "speak_language" "en") (test-speak)))
+    ))
+
 (run-all-tests)
 (exit)
 


### PR DESCRIPTION
Add new feature for speak.l. 

I'd like to switch speak-en and speak-jp online: (demos for japanese guests and english guests). 
I added speak-en-jp function and usage is:
```
(speak-en-jp "Hello world" "こんにちわ")
```
We need to write both japanese and english in speaking codes.
We can switch language by changing `speak_language` ros param.

Currently this is used in hrp2 73B2 demo and I copied the function into pr2eus.