### PR TITLE
[pr2eus_moveit] fix bug in &key in collision-object-publisher

### DIFF
--- a/pr2eus_moveit/euslisp/collision-object-publisher.l
+++ b/pr2eus_moveit/euslisp/collision-object-publisher.l
@@ -39,7 +39,7 @@
      (ros::publish attached-topicname msg)
      obj))
   (:make-object
-   (obj &key (frame-id "base_footprint") (object-frame-id) (relative-pose)
+   (obj &key (frame-id "base_footprint") (relative-pose)
         (object-id (string (gensym "COLOBJ"))) &allow-other-keys)
    (let ((msg (gethash obj object-list)))
      (when msg (return-from :make-object msg)))


### PR DESCRIPTION
What Changed:
- fix bug in `&key` passing in `collision-object-publisher`
  currently, we cannot modify `frame_id` from default `base_footprint`

```
$ rp echo /collision_object
header:
  seq: 0
  stamp:
    secs: 1480678340
    nsecs: 516131146
  frame_id: base_footprint
id: COLOBJ17254
type:
  key: ''
  db: ''
primitives:
  -
    type: 1
    dimensions: [0.3999999999999999, 0.3999999999999999, 0.3999999999999999]
primitive_poses:
  -
    position:
      x: 0.0
      y: 0.0
      z: 0.0
    orientation:
      x: 0.0
      y: 0.0
      z: 0.0
      w: 1.0
meshes: []
mesh_poses: []
planes: []
plane_poses: []
operation: 1
```


- remove unused key in collision-object-publisher