### PR TITLE
[pr2eus_moveit] remove unused key in collision-object-publisher

### DIFF
--- a/pr2eus_moveit/euslisp/collision-object-publisher.l
+++ b/pr2eus_moveit/euslisp/collision-object-publisher.l
@@ -39,7 +39,7 @@
      (ros::publish attached-topicname msg)
      obj))
   (:make-object
-   (obj &key (frame-id "base_footprint") (object-frame-id) (relative-pose)
+   (obj &key (frame-id "base_footprint") (relative-pose)
         (object-id (string (gensym "COLOBJ"))) &allow-other-keys)
    (let ((msg (gethash obj object-list)))
      (when msg (return-from :make-object msg)))


### PR DESCRIPTION
From #265

- remove unused `object-frame-id` in `collision-object-publisher`