### PR TITLE
[pr2eus_moveit/collision-object-publisher] support body class object

### DIFF
--- a/pr2eus_moveit/euslisp/collision-object-publisher.l
+++ b/pr2eus_moveit/euslisp/collision-object-publisher.l
@@ -101,7 +101,6 @@
        (let ((org-cds (send obj :copy-worldcoords)))
          (send obj :reset-coords)
          (send obj :worldcoords)
-         (send-all (send obj :bodies) :worldcoords)
          (let ((fs (body-to-faces obj))
                (geom (instance shape_msgs::mesh :init))
                idx-lst vertices (cntr 0))


### PR DESCRIPTION
What changed
- support body class object, which do not have `:bodies` method.