### PR TITLE
[pr2eus][pr2eus_moveit] use ctype in :send-trajectory and pass ctype in angle-vector-motion-plan

### DIFF
--- a/pr2eus/robot-interface.l
+++ b/pr2eus/robot-interface.l
@@ -905,15 +905,17 @@ Return value is a list of interpolatingp for all controllers, so (null (some #'i
   (:warningp (&optional (w :dummy)) "When warning mode, it wait for user's key input before sending angle-vector to the robot" (if (not (eq w :dummy)) (setq warningp w)) warningp)
   (:spin-once () (ros::spin-once groupname))
   (:send-trajectory (joint-trajectory-msg
-                     &key ((:controller-actions ca) controller-actions) ((:controller-type ct) controller-type)
-                     (starttime 1) &allow-other-keys)
+                     &key ((:controller-type ct) controller-type) (starttime 1) &allow-other-keys)
+   (unless (gethash ct controller-table)
+     (warn ";; controller-type: ~A not found" ct)
+     (return-from :send-trajectory))
    (mapcar
     #'(lambda (action param)
         (send self :send-trajectory-each
               action (cdr (assoc :joint-names param)) ;; action server and joint-names
               joint-trajectory-msg
               starttime))
-    ca (send self ct)))
+    (gethash ct controller-table) (send self ct)))
   (:send-trajectory-each
    (action joint-names traj &optional (starttime 0.2))
    (let* ((jnames (send traj :joint_names))

--- a/pr2eus_moveit/euslisp/robot-moveit.l
+++ b/pr2eus_moveit/euslisp/robot-moveit.l
@@ -570,8 +570,8 @@
        (if use-send-angle-vector
            (send* self :joint-trajectory-to-angle-vector-list move-arm traj args)
            (if start-offset-time
-             (send* self :send-trajectory traj :starttime start-offset-time args)
-             (send* self :send-trajectory traj args)))
+             (send* self :send-trajectory traj :controller-type ctype :starttime start-offset-time args)
+             (send* self :send-trajectory traj :controller-type ctype args)))
        (if (listp av) av (list av)))))
   (:move-end-coords-plan ;;
    (cds &rest args &key (move-arm :larm) (reset-total-time 5000.0) (use-send-angle-vector) &allow-other-keys)


### PR DESCRIPTION
### Changes
- [pr2eus] use only controller-type in send-trajectory
- [pr2eus_moveit] 	pass ctype in angle-vector-motion-plan

Fixes https://github.com/jsk-ros-pkg/jsk_robot/issues/776

@k-okada
I searched about `:send-trajectory`, but I didn't understand the reason why it has `controller-type` and `controller-action`.
My opinion is `controller-type` is necessary, and `controller-action` depends on it, as my first commit https://github.com/jsk-ros-pkg/jsk_pr2eus/pull/292/commits/d8b0aa6802ccc9f113a9aad8123221cc967004b2.
I'm afraid if this commit breaks API, but I couldn't find out other method which uses `:send-trajectory`.

cc. @Affonso-Gui 