### PR TITLE
[pr2eus][pr2-interface.l] add switch-controller methods

### DIFF
--- a/pr2eus/CMakeLists.txt
+++ b/pr2eus/CMakeLists.txt
@@ -9,11 +9,19 @@ else()
   message(STATUS "pr2_controllers_msgs IS DEPRECATED")
   set(PR2_CONTROLLERS_MSGS_PACKAGE )
 endif()
+find_package(pr2_mechanism_msgs QUIET)
+if(pr2_mechanism_msgs_FOUND)
+  message(STATUS "pr2_mechanism_msgs FOUND")
+  set(PR2_MECHANISM_MSGS_PACKAGE pr2_mechanism_msgs)
+else()
+  message(STATUS "pr2_mechanism_msgs NOT FOUND")
+  set(PR2_MECHANISM_MSGS_PACKAGE )
+endif()
 if($ENV{ROS_DISTRO} STREQUAL "hydro")
   set(GENEUS_PACKAGE geneus)
 endif()
 
-find_package(catkin REQUIRED COMPONENTS euscollada control_msgs nav_msgs dynamic_reconfigure rosgraph_msgs move_base_msgs pr2_msgs ${GENEUS_PACKAGE} ${PR2_CONTROLLERS_MSGS_PACKAGE} sound_play
+find_package(catkin REQUIRED COMPONENTS euscollada control_msgs nav_msgs dynamic_reconfigure rosgraph_msgs move_base_msgs pr2_msgs ${GENEUS_PACKAGE} ${PR2_CONTROLLERS_MSGS_PACKAGE} ${PR2_MECHANISM_MSGS_PACKAGE} sound_play
   roseus # this load roseus.cmake, so it needs to be located in the end
   )
 

--- a/pr2eus/package.xml
+++ b/pr2eus/package.xml
@@ -16,6 +16,7 @@
   <build_depend>pr2_msgs</build_depend>
   <build_depend>pr2_controllers_msgs</build_depend>
   <build_depend>pr2_description</build_depend>
+  <build_depend>pr2_mechanism_msgs</build_depend>
   <build_depend>control_msgs</build_depend>
   <build_depend>move_base_msgs</build_depend>
   <build_depend>nav_msgs</build_depend>
@@ -29,6 +30,7 @@
   <run_depend>pr2_msgs</run_depend>
   <run_depend>pr2_controllers_msgs</run_depend>
   <run_depend>pr2_description</run_depend>
+  <run_depend>pr2_mechanism_msgs</run_depend>
   <run_depend>control_msgs</run_depend>
   <run_depend>move_base_msgs</run_depend>
   <run_depend>nav_msgs</run_depend>

--- a/pr2eus/pr2-interface.l
+++ b/pr2eus/pr2-interface.l
@@ -19,6 +19,7 @@
 (ros::load-ros-manifest "pr2eus")
 (ros::load-ros-manifest "pr2_msgs")
 (ros::load-ros-manifest "pr2_controllers_msgs")
+(ros::load-ros-manifest "pr2_mechanism_msgs")
 (ros::load-ros-manifest "topic_tools")
 
 ;;;
@@ -460,7 +461,98 @@ Example: (send self :gripper :rarm :position) => 0.00"
      )) ; :angle-vector-with-constraint
   ) ;; defmethod pr2-interface
 
-   
+;; pr2 switch controllers
+(defmethod pr2-interface
+  (:list-controllers
+   ()
+   "Returns list of available controllers with cons where cdr is t if the controller is running state, nil otherwise.
+   "
+   (let ((srv-name "/pr2_controller_manager/list_controllers")
+         res)
+     (unless (ros::wait-for-service srv-name 10)
+       (ros::ros-error "service ~A is not advertised" srv-name)
+       (return-from :list-controllers nil))
+     (setq res (ros::service-call srv-name
+                                  (instance pr2_mechanism_msgs::ListControllersRequest :init)))
+     (mapcar #'cons (send res :controllers)
+             (mapcar #'(lambda (s) (string= s "running")) (send res :state)))))
+  (:switch-controller
+   (stop start &key (force))
+   "Switch controller
+    Args:
+        stop: controller name or list of controllers to stop
+        start: controller name or list of controllers to start
+        force: switch with strict policy if set to t, switch with best effort otherwise.
+    Returns: t if successfully switched controllers, nil otherwise.
+   "
+   (when (send self :simulation-modep)
+     (ros::ros-warn "switching controller is disabled on simulation mode.")
+     (return-from :switch-controller t))
+   (let ((srv-name "/pr2_controller_manager/switch_controller")
+         (req (instance pr2_mechanism_msgs::SwitchControllerRequest :init))
+         available res)
+     (unless (ros::wait-for-service srv-name 10)
+       (ros::ros-error "service ~A is not advertised" srv-name)
+       (return-from :switch-controller nil))
+     (setq available (mapcar #'car (send self :list-controllers)))
+     (when (set-difference (flatten stop) available :test #'string=)
+       (error "Unknown controller: ~A" (set-difference (flatten stop) available :test #'string=)))
+     (when (set-difference (flatten start) available :test #'string=)
+       (error "Unknown controller: ~A" (set-difference (flatten start) available :test #'string=)))
+     (send req :stop_controllers (or (flatten stop) "dummy_controller"))
+     (send req :start_controllers (or (flatten start) "dummy_controller"))
+     (send req :strictness
+           (if force
+               pr2_mechanism_msgs::SwitchControllerRequest::*STRICT*
+               pr2_mechanism_msgs::SwitchControllerRequest::*BEST_EFFORT*))
+     (setq res (ros::service-call srv-name req))
+     (if (send res :ok)
+         (ros::ros-info "switched controller ~A -> ~A" stop start)
+         (ros::ros-error "failed to switch controller ~A -> ~A" stop start))
+     (send res :ok)))
+  (:start-mannequin-mode
+   (&optional (controller t))
+   "Switch controller to loose_controller.
+    Args:
+        controller: :head :arms :rarm :larm, list of controllerse or t for all controllers
+    Returns: t if success, nil otherwise.
+    "
+   (when (eq controller t)
+     (setq controller (list :head :arms)))
+   (setq controller (flatten controller))
+   (let (stop start)
+     (when (memq :head controller)
+       (push "head_traj_controller" stop)
+       (push "head_traj_controller_loose" start))
+     (when (or (memq :larm controller) (memq :arms controller))
+       (push "l_arm_controller" stop)
+       (push "l_arm_controller_loose" start))
+     (when (or (memq :rarm controller) (memq :arms controller))
+       (push "r_arm_controller" stop)
+       (push "r_arm_controller_loose" start))
+     (send self :switch-controller stop start)))
+  (:stop-mannequin-mode
+   (&optional (controller t))
+   "Switch controller from loose_controller to normal controller.
+    Args:
+        controller: :head :arms :rarm :larm, list of controllerse or t for all controllers
+    Returns: t if success, nil otherwise.
+    "
+   (when (eq controller t)
+     (setq controller (list :head :arms)))
+   (setq controller (flatten controller))
+   (let (stop start)
+     (when (memq :head controller)
+       (push "head_traj_controller_loose" stop)
+       (push "head_traj_controller" start))
+     (when (or (memq :larm controller) (memq :arms controller))
+       (push "l_arm_controller_loose" stop)
+       (push "l_arm_controller" start))
+     (when (or (memq :rarm controller) (memq :arms controller))
+       (push "r_arm_controller_loose" stop)
+       (push "r_arm_controller" start))
+     (send self :switch-controller stop start))))
+
 
 ;;;;;
 ;;;;; utility functions pr2 robot


### PR DESCRIPTION
This PR is refactored version of #281.
Added methods for switching controllers:

```lisp
2.irteusgl$ send *ri* :list-controllers
(("base_controller" . t) ("base_odometry" . t) ("head_camera_trigger" . t) ("head_traj_controller" . t) ("head_traj_controller_loose") ("l_arm_controller"\
 . t) ("l_arm_controller_loose") ("l_forearm_cam_trigger" . t) ("l_gripper_controller" . t) ("l_gripper_sensor_controller" . t) ("laser_tilt_controller" .\
 t) ("projector_controller" . t) ("projector_trigger" . t) ("prosilica_inhibit_projector_controller" . t) ("r_arm_controller" . t) ("r_arm_controller_loos\
e") ("r_forearm_cam_trigger" . t) ("r_gripper_controller" . t) ("r_gripper_sensor_controller" . t) ("torso_controller" . t))
3.irteusgl$ send *ri* :start-mannequin-mode 
[ INFO] [1495346022.892181125]: switched controller (r_arm_controller l_arm_controller head_traj_controller) -> (r_arm_controller_loose l_arm_controller_l\
oose head_traj_controller_loose)
t
4.irteusgl$ send *ri* :stop-mannequin-mode
[ INFO] [1495346029.115634689]: switched controller (r_arm_controller_loose l_arm_controller_loose head_traj_controller_loose) -> (r_arm_controller l_arm_\
controller head_traj_controller)
t
```