### PR TITLE
[pr2eus_moveit] support tm :fast in :angle-vector-motion-plan

### DIFF
--- a/pr2eus_moveit/euslisp/robot-moveit.l
+++ b/pr2eus_moveit/euslisp/robot-moveit.l
@@ -269,6 +269,8 @@
            (setq extra-goal-constraints (list extra-goal-constraints)))
        (nconc (send mpr :goal_constraints) extra-goal-constraints))
      (if path-constraints (send mpr :path_constraints path-constraints))
+     ;; TrajectoryConstraints is not used in plannning
+     ;; Detailed info: https://github.com/ros-planning/moveit_msgs/issues/2
      (if trajectory-constraints (send mpr :trajectory_constraints trajectory-constraints))
      (send mpr :planner_id planner-id) ;; select from :query-planner-interface
      (send mpr :group_name group-name)

--- a/pr2eus_moveit/euslisp/robot-moveit.l
+++ b/pr2eus_moveit/euslisp/robot-moveit.l
@@ -525,7 +525,7 @@
      ret))
   (:angle-vector-motion-plan ;;
    (av &rest args &key (ctype controller-type) (start-offset-time) (total-time)
-       (move-arm :larm) (reset-total-time 5000.0) (use-send-angle-vector)
+       (move-arm :larm) (reset-total-time 5000.0) (use-send-angle-vector) (scale 1.0)
        &allow-other-keys)
    (let (traj ret orig-total-time)
      (setq ctype (or ctype controller-type))
@@ -545,7 +545,7 @@
        (ros::ros-info ";; Planned Trajectory Total Time ~7,3f [sec]" orig-total-time)
        (setq total-time
              (cond
-               ((eq total-time :fast) (* orig-total-time 1000))
+               ((eq total-time :fast) (* scale (* orig-total-time 1000)))
                ((or (null total-time) (> orig-total-time (/ total-time 1000))) (* orig-total-time 1000))
                (t total-time)))
        (setq traj (send* self :trajectory-filter traj :start-offset-time start-offset-time :total-time total-time args))

--- a/pr2eus_moveit/euslisp/robot-moveit.l
+++ b/pr2eus_moveit/euslisp/robot-moveit.l
@@ -240,6 +240,7 @@
             (workspace-x 1.0) (workspace-y 1.0) (workspace-z 1.6)
             (goal-constraints) (extra-goal-constraints)
             (path-constraints) (trajectory-constraints)
+            (max-velocity-scale) (max-acceleration-scale)
             &allow-other-keys)
    (let ((group-name (cdr (assoc :group-name (cdr (assoc confkey config-list)))))
          (mpr (instance moveit_msgs::motionplanrequest :init))
@@ -273,6 +274,8 @@
      (send mpr :group_name group-name)
      (send mpr :num_planning_attempts planning-attempts)
      (send mpr :allowed_planning_time planning-time)
+     (when max-velocity-scale (send mpr :max_velocity_scaling_factor max-velocity-scale))
+     (when max-acceleration-scale (send mpr :max_acceleration_scaling_factor max-acceleration-scale))
      ;;(print-ros-msg mpr)
      (when use-action
        (send self :init-action-client)

--- a/pr2eus_moveit/euslisp/robot-moveit.l
+++ b/pr2eus_moveit/euslisp/robot-moveit.l
@@ -522,7 +522,7 @@
    (av &rest args &key (ctype controller-type) (start-offset-time) (total-time)
        (move-arm :larm) (reset-total-time 5000.0) (use-send-angle-vector)
        &allow-other-keys)
-   (let (traj ret filtered orig-total-time)
+   (let (traj ret orig-total-time)
      (setq ctype (or ctype controller-type))
      (unless (gethash ctype controller-table)
        (warn ";; controller-type: ~A not found" ctype)
@@ -538,18 +538,14 @@
          (ros::ros-warn "reset Trajectory Total time")
          (setq traj (send* self :trajectory-filter traj :start-offset-time start-offset-time :total-time reset-total-time args)))
        (ros::ros-info ";; Planned Trajectory Total Time ~7,3f [sec]" orig-total-time)
-       (when (and total-time ;; [msec]
-                  (< orig-total-time
-                     (/ total-time 1000)))
-         (setq filtered t)
-         (setq traj (send* self :trajectory-filter traj :start-offset-time start-offset-time :total-time total-time args))
-         (setq orig-total-time (/ total-time 1000))
-         (ros::ros-info ";; Scaled Trajectory Total Time ~7,3f [sec]" (/ total-time 1000)))
-       (when (and start-offset-time (null filtered))
-         (setq traj (send* self :trajectory-filter traj :start-offset-time start-offset-time :total-time (* orig-total-time 1000.0) args)) ;; :total-time [msec]
-         (ros::ros-info ";; Scaled Trajectory Total Time ~7,3f [sec]" orig-total-time))
-
-       (ros::ros-info ";; generated ~A points for ~A sec using [~A] group" (length (send traj :points)) orig-total-time (send ret :group_name))
+       (setq total-time
+             (cond
+               ((eq total-time :fast) (* orig-total-time 1000))
+               ((or (null total-time) (> orig-total-time (/ total-time 1000))) (* orig-total-time 1000))
+               (t total-time)))
+       (setq traj (send* self :trajectory-filter traj :start-offset-time start-offset-time :total-time total-time args))
+       (ros::ros-info ";; Scaled Trajectory Total Time ~7,3f [sec]" (/ total-time 1000))
+       (ros::ros-info ";; generated ~A points for ~A sec using [~A] group" (length (send traj :points)) (/ total-time 1000) (send ret :group_name))
        ;;
        (mapcar
         #'(lambda (action param)
@@ -561,8 +557,8 @@
               (maphash #'(lambda (ac ct)
                            (if (equal (list action) ct)
                              (if (listp av)
-                               (send-message self robot-interface :angle-vector-sequence av (* orig-total-time 1000) ac)
-                               (send-message self robot-interface :angle-vector av (* orig-total-time 1000) ac))))
+                               (send-message self robot-interface :angle-vector-sequence av total-time ac)
+                               (send-message self robot-interface :angle-vector av total-time ac))))
                        controller-table)
               ))
         controller-actions (send self controller-type))


### PR DESCRIPTION
When `max_velocity_scaling_factor`  and `max_acceleration_scaling_factor` is `1.0` in  `MotionPlanRequest`, it is same as `:fast` in `:angle-vector-raw`

# Changes
- support tm `:fast` in `:angle-vector-motion-plan`
- add `:scale` key in `:angle-vector-motion-plan`

# Minor Changes
- add `trajectory_constraints` comment out
- add `max_velocity_scaling_factor` and `max_acceleration_scaling_factor` key