### PR TITLE
[pr2eus_moveit] send angle-vector only once in :angle-vector-motion-plan

### DIFF
--- a/pr2eus_moveit/euslisp/robot-moveit.l
+++ b/pr2eus_moveit/euslisp/robot-moveit.l
@@ -566,7 +566,7 @@
                       (send-message self robot-interface :angle-vector-sequence av total-time (car ct))
                       (send-message self robot-interface :angle-vector av total-time (car ct)))
                   (return)))))
-        controller-actions (send self controller-type))
+        controller-actions (send self ctype))
 
        (if use-send-angle-vector
            (send* self :joint-trajectory-to-angle-vector-list move-arm traj args)

--- a/pr2eus_moveit/euslisp/robot-moveit.l
+++ b/pr2eus_moveit/euslisp/robot-moveit.l
@@ -559,13 +559,13 @@
                     (find param (send self ctype) :test #'equal)
                     (not (intersection (send traj :joint_names) (cdr (assoc :joint-names param)) :test #'string=)))
               ;; send via :angle-vector
-              (maphash #'(lambda (ac ct)
-                           (if (equal (list action) ct)
-                             (if (listp av)
-                               (send-message self robot-interface :angle-vector-sequence av total-time ac)
-                               (send-message self robot-interface :angle-vector av total-time ac))))
-                       controller-table)
-              ))
+              (dolist (ct (send controller-table :list))
+                (when (and (> (length ct) 1)
+                         (equal (list action) (cdr ct)))
+                  (if (listp av)
+                      (send-message self robot-interface :angle-vector-sequence av total-time (car ct))
+                      (send-message self robot-interface :angle-vector av total-time (car ct)))
+                  (return)))))
         controller-actions (send self controller-type))
 
        (if use-send-angle-vector


### PR DESCRIPTION
Current code sends angle-vector twice to non-moveit controller like `head-controller` if the condition `(equal (list action) ct)` is satisfied.
