### PR TITLE
[pr2eus_moveit] fix typo in robot-moveit.l

### DIFF
--- a/pr2eus_moveit/euslisp/robot-moveit.l
+++ b/pr2eus_moveit/euslisp/robot-moveit.l
@@ -566,7 +566,7 @@
                                (send-message self robot-interface :angle-vector av total-time ac))))
                        controller-table)
               ))
-        controller-actions (send self controller-type))
+        controller-actions (send self ctype))
 
        (if use-send-angle-vector
            (send* self :joint-trajectory-to-angle-vector-list move-arm traj args)


### PR DESCRIPTION
- Fix typo:
  - `controller-type` -> `ctype`

cc. @pazeshun