### PR TITLE
add test for https://github.com/jsk-ros-pkg/jsk_pr2eus/pull/310#issuecomment-314694668

### DIFF
--- a/pr2eus_moveit/euslisp/robot-moveit.l
+++ b/pr2eus_moveit/euslisp/robot-moveit.l
@@ -549,7 +549,7 @@
                ((or (null total-time) (> orig-total-time (/ total-time 1000.0))) (* orig-total-time 1000))
                (t total-time)))
        (setq traj (send* self :trajectory-filter traj :start-offset-time start-offset-time :total-time total-time args))
-       (ros::ros-info ";; Scaled Trajectory Total Time ~7,3f [sec]" (/ total-time 1000.0))
+       (ros::ros-info ";; Scaled Trajectory Total Time ~0,3f(~0,3f) [sec]" (send (send (car (last (send traj :points))) :time_from_start) :to-sec) (/ total-time 1000.0))
        (ros::ros-info ";; generated ~A points for ~A sec using [~A] group" (length (send traj :points)) (/ total-time 1000.0) (send ret :group_name))
        (ros::ros-info ";; will send to ~A" (send traj :joint_names))
        ;;

--- a/pr2eus_moveit/euslisp/robot-moveit.l
+++ b/pr2eus_moveit/euslisp/robot-moveit.l
@@ -524,7 +524,7 @@
                     cds confkey :end-coords ed-lst args))
      ret))
   (:angle-vector-motion-plan ;;
-   (av &rest args &key (ctype controller-type) (start-offset-time) (total-time)
+   (av &rest args &key (ctype controller-type) (start-offset-time 0) (total-time)
        (move-arm :larm) (reset-total-time 5000.0) (use-send-angle-vector) (scale 1.0)
        &allow-other-keys)
    (let (traj ret orig-total-time sent-controller)
@@ -600,7 +600,7 @@
          (send* self :send-trajectory traj args))
        )))
   (:trajectory-filter ;; simple trajectory for zero duration
-   (traj &key (copy) (total-time 5000.0) (minimum-time 0.001) (start-offset-time) (clear-velocities) &rest args &allow-other-keys)
+   (traj &key (copy) (total-time 5000.0) (minimum-time 0.001) (start-offset-time 0) (clear-velocities) &rest args &allow-other-keys)
    (let ((orig-total-time (send (send (car (last (send traj :points))) :time_from_start) :to-sec)))
    (when (and minimum-time (not start-offset-time)
               (> orig-total-time

--- a/pr2eus_moveit/euslisp/robot-moveit.l
+++ b/pr2eus_moveit/euslisp/robot-moveit.l
@@ -546,11 +546,11 @@
        (setq total-time
              (cond
                ((eq total-time :fast) (* scale (* orig-total-time 1000)))
-               ((or (null total-time) (> orig-total-time (/ total-time 1000))) (* orig-total-time 1000))
+               ((or (null total-time) (> orig-total-time (/ total-time 1000.0))) (* orig-total-time 1000))
                (t total-time)))
        (setq traj (send* self :trajectory-filter traj :start-offset-time start-offset-time :total-time total-time args))
-       (ros::ros-info ";; Scaled Trajectory Total Time ~7,3f [sec]" (/ total-time 1000))
-       (ros::ros-info ";; generated ~A points for ~A sec using [~A] group" (length (send traj :points)) (/ total-time 1000) (send ret :group_name))
+       (ros::ros-info ";; Scaled Trajectory Total Time ~7,3f [sec]" (/ total-time 1000.0))
+       (ros::ros-info ";; generated ~A points for ~A sec using [~A] group" (length (send traj :points)) (/ total-time 1000.0) (send ret :group_name))
        (ros::ros-info ";; will send to ~A" (send traj :joint_names))
        ;;
        (mapcar

--- a/pr2eus_moveit/test/test-pr2eus-moveit.l
+++ b/pr2eus_moveit/test/test-pr2eus-moveit.l
@@ -108,6 +108,21 @@
     (assert (> tm-diff 3) (format nil "collsion avoidance motion is too fast ~A" tm-diff))
     ))
 
+;; do not send faster command than moveit output
+(deftest test-moveit-fastest-trajectory ()
+  (let (tm-0 tm-1 tm-diff)
+    (send *ri* :angle-vector (send *pr2* :reset-pose))
+    (send *ri* :wait-interpolation)
+    (send *pr2* :rarm :angle-vector #f(0 0 0 0 0 0 0))
+    (send *ri* :angle-vector-motion-plan (send *pr2* :angle-vector) :total-time 1000 :move-arm :rarm :use-torso nil)
+    (setq tm-0 (ros::time-now))
+    (send *ri* :wait-interpolation)
+    (setq tm-1 (ros::time-now))
+    (setq tm-diff (send (ros::time- tm-1 tm-0) :to-sec))
+    (ros::ros-info "time for duration ~A" tm-diff)
+    (assert (> tm-diff 3) (format nil "collsion avoidance motion is too fast ~A" tm-diff))
+    ))
+
 (run-all-tests)
 (exit)
 


### PR DESCRIPTION
https://github.com/jsk-ros-pkg/jsk_pr2eus/pull/310#issuecomment-314694668

CAUTION: 21ed50b changes to set start-offset-time to 0 as default value, other wise, if we do not set this value, we'll skip trajectory-filter very easily 

```
  (:trajectory-filter ;; simple trajectory for zero duration
   (traj &key (copy) (total-time 5000.0) (minimum-time 0.001) (start-offset-time) (clear-velocities) &rest args &allow-other-keys)
   (let ((orig-total-time (send (send (car (last (send traj :points))) :time_from_start) :to-sec)))
   (when (and minimum-time (not start-offset-time)
              (> orig-total-time
                 minimum-time))
     (ros::ros-warn ";; Trajectory Filter will not work, start-offset-time : ~A, minimum-time : ~A, first point in trajectory ~A" start-offset-time minimum-time orig-total-time)
     (return-from :trajectory-filter traj)
```


- 4cd0b85 (Kei Okada, 35 seconds ago)
    test/test-pr2eus-moveit.l, add test-moveit-fastest-trajectory, ensure that
    :angle-vector-motion-plan will not send faster motion then moveit planned
    motion
- 5f3c487 (Kei Okada, 2 minutes ago)
    display both scaled trajectory time and actual time_to_start time
- 21ed50b (Kei Okada, 7 minutes ago)
    robot-moveit.l : set default start-offset-time to 0, not to skip
    :trajectory-filter
- 45852d2 (Kei Okada, 28 minutes ago)
    robot-moveit.l, fix debug info (/ total-time 1000) -> (/ total-time 1000.0)