### PR TITLE
pr2eus: add text-to-spech method to robot-interface

### DIFF
--- a/pr2eus/robot-interface.l
+++ b/pr2eus/robot-interface.l
@@ -1039,6 +1039,7 @@ Return value is a list of interpolatingp for all controllers, so (null (some #'i
    "get information about gripper"
    (error "This method is responsible to sub class~%"))
   ) ;; robot-interface
+
 ;; ros visualization methods
 (defmethod robot-interface
   (:joint-trajectory-to-angle-vector-list
@@ -1187,6 +1188,26 @@ Return value is a list of interpolatingp for all controllers, so (null (some #'i
    (warn ";; Stop Euslisp mannequin mode.~%")
    )
   )
+;;
+;; for text-to-speech services
+(defmethod robot-interface
+  (:speak (text &rest args &key (lang :en) &allow-other-keys)
+    "Speak sentence using text-to-speech services.
+     Args:
+        text: sentence to speak
+        lang: language to speak, currently :en or :ja are supported.
+        args: other key arguments are passed to speech functions"
+    (case lang
+     (:en (send* self :speak-en text (remprop :lang args)))
+     (:ja (send* self :speak-jp text (remprop :lang args)))
+     (t (error "Unsupported language ~A" lang))))
+  (:speak-en (text &rest args)
+    "Speak english sentence"
+    (apply #'speak-en text args))
+  (:speak-jp (text &rest args)
+    "Speak japanese sentence"
+    (apply #'speak-jp text args))
+) ;; defmethod robot-interface (text-to-speech)
 ;;
 (defclass robot-move-base-interface
   :super robot-interface

--- a/pr2eus/robot-interface.l
+++ b/pr2eus/robot-interface.l
@@ -4,6 +4,7 @@
 (ros::load-ros-manifest "roseus")
 (ros::load-ros-manifest "rosgraph_msgs")
 (ros::load-ros-manifest "control_msgs")
+(ros::load-ros-manifest "sound_play")
 ;;(ros::roseus-add-msgs "sensor_msgs") ;; roseus depends on sensor_msgs
 ;;(ros::roseus-add-msgs "visualization_msgs") ;; roseus depends on visualization_msgs
 (ros::roseus-add-msgs "move_base_msgs")
@@ -1191,22 +1192,63 @@ Return value is a list of interpolatingp for all controllers, so (null (some #'i
 ;;
 ;; for text-to-speech services
 (defmethod robot-interface
-  (:speak (text &rest args &key (lang :en) &allow-other-keys)
+  (:speak-timeout (&optional timeout)
+   (when timeout (send self :put :speak-timeout timeout))
+   (or (send self :get :speak-timeout) 10))
+  (:speak-action-client (&optional topic-name)
+   (unless (send self :get :speak-action-clients)
+     (return-from :speak-action-client nil))
+   (if topic-name
+       (gethash topic-name (send self :get :speak-action-clients))
+       (send (send self :get :speak-action-clients) :list-values)))
+  (:speak-raw (msg &key (topic-name "robotsound") wait)
+   (when (boundp 'sound_play::SoundRequestAction)
+     (unless (send self :speak-action-client)
+       (send self :put :speak-action-clients (make-hash-table :test #'equal)))
+     (let ((goal (instance sound_play::SoundRequestActionGoal :init))
+           (ac (or
+                (send self :speak-action-client topic-name)
+                (instance ros::simple-action-client :init
+                          topic-name
+                          sound_play::SoundRequestAction
+                          :groupname "speak"))))
+       (if (send ac :wait-for-server 1)
+           (progn
+             (send goal :goal :sound_request msg)
+             (setf (gethash topic-name
+                            (send self :get :speak-action-clients)) ac)
+             (if wait
+                 (send ac :send-goal-and-wait goal :timeout (send self :speak-timeout))
+                 (send ac :send-goal goal))
+             (return-from :speak-raw t))
+           (ros::ros-warn "action server /~A not found. continue without waiting for the end of speech.." topic-name))))
+   ;; use topic instead of actionlib
+   (unless (ros::get-topic-publisher topic-name)
+     (ros::advertise topic-name sound_play::SoundRequest 5)
+     (unix:sleep 1))
+   (ros::publish topic-name msg)
+   t)
+  (:speak (text &key (lang "") (topic-name "robotsound") wait)
     "Speak sentence using text-to-speech services.
      Args:
         text: sentence to speak
         lang: language to speak, currently :en or :ja are supported.
-        args: other key arguments are passed to speech functions"
-    (case lang
-     (:en (send* self :speak-en text (remprop :lang args)))
-     (:ja (send* self :speak-jp text (remprop :lang args)))
-     (t (error "Unsupported language ~A" lang))))
+        wait: wait the end of speech if enabled"
+    (send self :speak-raw
+          (instance sound_play::SoundRequest :init
+                    :sound sound_play::SoundRequest::*say*
+                    :command sound_play::SoundRequest::*play_once*
+                    :arg text
+                    :arg2 (string-downcase lang))
+          :topic-name topic-name
+          :wait wait))
   (:speak-en (text &rest args)
     "Speak english sentence"
-    (apply #'speak-en text args))
-  (:speak-jp (text &rest args)
+    (send* self :speak text :lang "" args))
+  (:speak-jp (text &rest args &key (topic-name "robotsound_jp") &allow-other-keys)
     "Speak japanese sentence"
-    (apply #'speak-jp text args))
+    (setq args (append args (list :topic-name topic-name)))
+    (send* self :speak text :lang :ja args))
 ) ;; defmethod robot-interface (text-to-speech)
 ;;
 (defclass robot-move-base-interface

--- a/pr2eus/speak.l
+++ b/pr2eus/speak.l
@@ -3,56 +3,6 @@
 
 (ros::load-ros-manifest "sound_play")
 
-(defparameter *speak-wait* nil)
-(defparameter *speak-action-clients* (make-hash-table))
-(defparameter *speak-timeout* 20)
-
-(defun send-speak-msg (msg
-                       &key (topic-name "robotsound")
-                            (timeout *speak-timeout*)
-                            (wait *speak-wait*))
-  (cond
-    ((boundp 'sound_play::soundrequestaction)
-      (let ((goal (instance sound_play::SoundRequestActionGoal :init))
-            (action-client-key (intern (string-upcase topic-name) *keyword-package*)))
-        (unless (gethash action-client-key *speak-action-clients*)
-          (setf (gethash action-client-key *speak-action-clients*)
-                (instance ros::simple-action-client :init
-                          topic-name sound_play::SoundRequestAction :groupname "speak")))
-        (let ((ac (gethash action-client-key *speak-action-clients*)))
-          (unless (send ac :wait-for-server timeout)
-            (ros::ros-error "action server /~A is not found. sound_play node is not alive?" topic-name)
-            (return-from send-speak-msg nil))
-          (send goal :goal :sound_request msg)
-          (send ac :send-goal goal)
-          (if wait
-            (send ac :wait-for-result :timeout timeout) t))))
-    (t ;; action client is not used for backward compatibility
-      (unless (ros::get-topic-publisher topic-name)
-        (ros::advertise topic-name sound_play::SoundRequest 5)
-        (unix:sleep 1))
-      (ros::publish topic-name msg)
-      t)))
-
-(defun speak (text &key (lang "") (topic-name "robotsound") wait timeout)
-  "Speak sentence using text-to-speech service.
-
-   Args:
-    - text: sentence to speak
-    - lang: language of sentence
-    - topic-name: topic name space for sound_play server
-    - wait: wait the end of speech if enabled
-    - timeout: timeout for waiting, this is valid only if wait is enabled"
-  (send-speak-msg
-   (instance sound_play::SoundRequest :init
-             :sound sound_play::SoundRequest::*say*
-             :command sound_play::SoundRequest::*play_once*
-             :arg text
-             :arg2 (string-downcase lang))
-   :topic-name topic-name
-   :wait (or wait *speak-wait*)
-   :timeout (or timeout *speak-timeout*)))
-
 (defun speak-jp (text &key wait timeout (topic-name "robotsound_jp"))
   "Speak japanese sentence using text-to-speech service.
 
@@ -61,7 +11,19 @@
     - topic-name: topic name space for sound_play server
     - wait: wait the end of speech if enabled
     - timeout: timeout for waiting, this is valid only if wait is enabled"
-  (speak text :lang "ja" :wait wait :timeout timeout :topic-name topic-name))
+
+  (unless (boundp '*ri*)
+    (ros::ros-error "Instantiate *ri* first to use text-to-speech.")
+    (return-from speak-jp nil))
+  (ros::ros-warn "The function `speak-jp` is deprecated, please use (send *ri* :speak-jp \"text\")")
+
+  (let ((timeout-bak (send *ri* :speak-timeout)))
+    (when timeout
+      (send *ri* :speak-timeout timeout))
+    (prog1
+        (send *ri* :speak-jp text :wait wait :topic-name topic-name)
+      (when timeout
+        (send *ri* :speak-timeout timeout-bak)))))
 
 (defun speak-en (text &key wait timeout (topic-name "robotsound"))
   "Speak english sentence using text-to-speech service.
@@ -71,6 +33,18 @@
     - topic-name: topic name space for sound_play server
     - wait: wait the end of speech if enabled
     - timeout: timeout for waiting, this is valid only if wait is enabled"
-  (speak text :lang "" :wait wait :timeout timeout :topic-name topic-name))
+
+  (unless (boundp '*ri*)
+    (ros::ros-error "Instantiate *ri* first to use text-to-speech.")
+    (return-from speak-en nil))
+  (ros::ros-warn "The function `speak-en` is deprecated, please use (send *ri* :speak-en \"text\")")
+
+  (let ((timeout-bak (send *ri* :speak-timeout)))
+    (when timeout
+      (send *ri* :speak-timeout timeout))
+    (prog1
+        (send *ri* :speak-en text :wait wait :topic-name topic-name)
+      (when timeout
+        (send *ri* :speak-timeout timeout-bak)))))
 
 (provide :speak) ;; end of speak.l

--- a/pr2eus/speak.l
+++ b/pr2eus/speak.l
@@ -8,7 +8,8 @@
 (defparameter *speak-timeout* 20)
 
 (defun send-speak-msg (msg
-                       &key (topic-name "robotsound") (timeout *speak-timeout*)
+                       &key (topic-name "robotsound")
+                            (timeout *speak-timeout*)
                             (wait *speak-wait*))
   (cond
     ((boundp 'sound_play::soundrequestaction)
@@ -33,46 +34,43 @@
       (ros::publish topic-name msg)
       t)))
 
-(defun speak-google (str &key (lang :ja) (wait *speak-wait*) (topic-name "robotsound") (timeout *speak-timeout*))
-  (let* ((qstr (escaped-url-string-from-namestring
-                (concatenate string
-                             "http://translate.google.com/translate_tts?tl="
-                             (string-downcase (string lang))
-                             "&client=t&ie=UTF-8&q=" str)))
-         (msg (instance sound_play::SoundRequest :init
-                        :sound sound_play::SoundRequest::*play_file*
-                        :command sound_play::SoundRequest::*play_once*
-                        :arg qstr)))
-    (send-speak-msg msg
-                    :topic-name topic-name
-                    :wait wait
-                    :timeout timeout)))
+(defun speak (text &key (lang "") (topic-name "robotsound") wait timeout)
+  "Speak sentence using text-to-speech service.
 
-(defun speak-jp (str &key google (wait *speak-wait*) (topic-name "robotsound_jp") (timeout *speak-timeout*))
-  (when google
-      (return-from speak-jp
-        (speak-google str :lang :ja :wait wait :timeout timeout)))
+   Args:
+    - text: sentence to speak
+    - lang: language of sentence
+    - topic-name: topic name space for sound_play server
+    - wait: wait the end of speech if enabled
+    - timeout: timeout for waiting, this is valid only if wait is enabled"
   (send-speak-msg
    (instance sound_play::SoundRequest :init
              :sound sound_play::SoundRequest::*say*
              :command sound_play::SoundRequest::*play_once*
-             :arg str
-             :arg2 "aq_rm.phont")
+             :arg text
+             :arg2 (string-downcase lang))
    :topic-name topic-name
-   :wait wait
-   :timeout timeout))
+   :wait (or wait *speak-wait*)
+   :timeout (or timeout *speak-timeout*)))
 
-(defun speak-en (str &key google (wait *speak-wait*) (topic-name "robotsound") (timeout *speak-timeout*))
-  (when google
-    (return-from speak-en
-            (speak-google str :lang :en :wait wait :timeout timeout)))
-  (send-speak-msg
-   (instance sound_play::SoundRequest :init
-             :sound sound_play::SoundRequest::*say*
-             :command sound_play::SoundRequest::*play_once*
-             :arg str)
-   :topic-name topic-name
-   :wait wait
-   :timeout timeout))
+(defun speak-jp (text &key wait timeout (topic-name "robotsound_jp"))
+  "Speak japanese sentence using text-to-speech service.
+
+   Args:
+    - text: sentence to speak
+    - topic-name: topic name space for sound_play server
+    - wait: wait the end of speech if enabled
+    - timeout: timeout for waiting, this is valid only if wait is enabled"
+  (speak text :lang :ja :wait wait :timeout timeout :topic-name topic-name))
+
+(defun speak-en (text &key wait timeout (topic-name "robotsound"))
+  "Speak english sentence using text-to-speech service.
+
+   Args:
+    - text: sentence to speak
+    - topic-name: topic name space for sound_play server
+    - wait: wait the end of speech if enabled
+    - timeout: timeout for waiting, this is valid only if wait is enabled"
+  (speak text :lang "" :wait wait :timeout timeout :topic-name topic-name))
 
 (provide :speak) ;; end of speak.l

--- a/pr2eus/speak.l
+++ b/pr2eus/speak.l
@@ -61,7 +61,7 @@
     - topic-name: topic name space for sound_play server
     - wait: wait the end of speech if enabled
     - timeout: timeout for waiting, this is valid only if wait is enabled"
-  (speak text :lang :ja :wait wait :timeout timeout :topic-name topic-name))
+  (speak text :lang "ja" :wait wait :timeout timeout :topic-name topic-name))
 
 (defun speak-en (text &key wait timeout (topic-name "robotsound"))
   "Speak english sentence using text-to-speech service.

--- a/pr2eus/test/speak-test.l
+++ b/pr2eus/test/speak-test.l
@@ -26,11 +26,13 @@
 
 (deftest test-speak-en ()
   (assert (speak-en "hello, world" :timeout 10))
-  (assert (send *ri* :speak-en "hello, world" :timeout 10)))
+  (assert (send *ri* :speak-en "hello, world"))
+  (assert (send *ri* :speak-en "good bye!" :wait t)))
 
 (deftest test-speak-jp ()
   (assert (speak-jp "こんにちは" :timeout 10))
-  (assert (send *ri* :speak-jp "こんにちは" :timeout 10)))
+  (assert (send *ri* :speak-jp "こんにちは"))
+  (assert (send *ri* :speak-jp "またね" :wait t)))
 
 (run-all-tests)
 (exit)

--- a/pr2eus/test/speak-test.l
+++ b/pr2eus/test/speak-test.l
@@ -3,23 +3,34 @@
 
 (require :unittest "lib/llib/unittest.l")
 
+(load "irteus/demo/sample-robot-model.l")
+(load "package://pr2eus/robot-interface.l")
 (load "package://pr2eus/speak.l")
+
 (ros::roseus "test_speak")
 
 (init-unit-test)
 
+(defclass sample-robot-interface
+  :super robot-interface
+  :slots ())
+(defmethod sample-robot-interface
+  (:init
+   (&rest args)
+   (send-super* :init :robot sample-robot args)
+   self))
+
+(when (not (boundp '*ri*))
+  (setq *ri* (instance sample-robot-interface :init)))
+
+
 (deftest test-speak-en ()
   (assert (speak-en "hello, world" :timeout 10))
-;;  (assert (speak-en "hello, world" :timeout 10 :wait t))
-  (assert (speak-en "hello, world" :timeout 10 :google t)))
+  (assert (send *ri* :speak-en "hello, world" :timeout 10)))
 
 (deftest test-speak-jp ()
   (assert (speak-jp "こんにちは" :timeout 10))
-;;  (assert (speak-jp "こんにちは" :timeout 10 :wait t))
-  (assert (speak-jp "こんにちは" :timeout 10 :google t)))
-
-(deftest test-speak-google ()
-  (assert (speak-google "bonjour" :timeout 10 :lang :fr)))
+  (assert (send *ri* :speak-jp "こんにちは" :timeout 10)))
 
 (run-all-tests)
 (exit)


### PR DESCRIPTION
Also addressed in https://github.com/jsk-ros-pkg/jsk_robot/pull/833

This PR includes:
- Cleanup unused text-to-speech methods
- Add text-to-speech method caller to robot-interface