### PR TITLE
Fix :end-coords-interpolation problems

### DIFF
--- a/pr2eus/pr2-interface.l
+++ b/pr2eus/pr2-interface.l
@@ -372,7 +372,7 @@ Example: (send self :gripper :rarm :position) => 0.00"
      ))
   (:angle-vector-sequence
    (avs &optional (tms (list 3000)) &rest args)
-   (unless (send self :simulation-modep)
+   (unless (or (send self :simulation-modep) (cadr (memq :end-coords-interpolation args)))
      (let* ((prev-av (send robot :angle-vector (send self :state :reference-vector)))
             (len-av (length prev-av))
             (max-av (fill (instantiate float-vector len-av)  180))

--- a/pr2eus/robot-interface.l
+++ b/pr2eus/robot-interface.l
@@ -440,6 +440,7 @@
        (let ((av-orig (send robot :angle-vector)) ;; initial av, restore at end
              (c-orig  (send robot :copy-worldcoords)) ;; inital coords, restore at end
              (av-prev-orig av-prev) ;; prev-av
+	     (diff-prev (instantiate float-vector (length av-prev))) diff ;; for over 360 deg turns
              (limbs '(:larm :rarm :lleg :rleg)) ;; do not move :head and :torso by IK
              target-limbs
              (minjerk (instance minjerk-interpolator :init))
@@ -454,6 +455,7 @@
          (dolist (av avs)
            (send robot :angle-vector av)
            (setq end-coords-current (mapcar #'(lambda (limb) (send robot limb :end-coords :copy-worldcoords)) limbs))
+	   (setq diff (v- (v- av (setq av (v+ av-prev (send self :sub-angle-vector av av-prev)))) diff-prev))
            (setq target-limbs nil)
 	   (setq tm (elt tms i))
 	   (setq pass-tm (/ tm (float end-coords-interpolation-steps)))
@@ -478,10 +480,10 @@
                            ec-current (elt end-coords-current (position limb limbs)))
                      (setq ret (and ret
                                     (send robot limb :inverse-kinematics (midcoords p ec-prev ec-current)))))
-                   (push (send robot :angle-vector) interpolated-avs)
+                   (push (v++ diff-prev (scale p diff) (send robot :angle-vector)) interpolated-avs)
                    (push pass-tm interpolated-tms)
                    )
-               (push av interpolated-avs)
+               (push (v++ diff-prev diff av) interpolated-avs)
                (push pass-tm interpolated-tms)
 	       )
              (progn
@@ -489,6 +491,7 @@
                (push tm interpolated-tms)))
            (setq end-coords-prev end-coords-current)
            (setq av-prev av)
+	   (setq diff-prev diff)
            (incf i)) ;; dolist (av avs)
          ;; restore states
          (setq avs (nreverse interpolated-avs) tms (nreverse interpolated-tms))

--- a/pr2eus/robot-interface.l
+++ b/pr2eus/robot-interface.l
@@ -349,7 +349,7 @@
    (let* ((prev-av (send robot :angle-vector)))
      (send-all (gethash ctype controller-table) :push-angle-vector-simulation av tm prev-av)))
   (:angle-vector
-   (av &optional (tm nil) (ctype controller-type) (start-time 0) &key (scale 1) (min-time 1.0) (end-coords-interpolation nil))
+   (av &optional (tm nil) (ctype controller-type) (start-time 0) &key (scale 1) (min-time 1.0) (end-coords-interpolation nil) (end-coords-interpolation-steps 10))
    "Send joind angle to robot, this method retuns immediately, so use :wait-interpolation to block until the motion stops.
 - av : joint angle vector [deg]
 - tm : (time to goal in [msec])
@@ -361,9 +361,10 @@
 - scale : if tm is not specified, it will use 1/scale of the fastest speed
 - min-time : minimum time for time to goal
 - end-coords-interpolation : set t if you want to move robot in cartesian space interpolation
+- end-coords-interpolation-steps : number of divisions when interpolating end-coords
 "
    (if end-coords-interpolation
-     (return-from :angle-vector (send self :angle-vector-sequence (list av) (list tm) ctype start-time :scale scale :min-time min-time :end-coords-interpolation t)))
+     (return-from :angle-vector (send self :angle-vector-sequence (list av) (list tm) ctype start-time :scale scale :min-time min-time :end-coords-interpolation t :end-coords-interpolation-steps end-coords-interpolation-steps)))
    (setq ctype (or ctype controller-type))  ;; use default controller-type if ctype is nil
    (unless (gethash ctype controller-table)
      (warn ";; controller-type: ~A not found" ctype)
@@ -404,7 +405,7 @@
       cacts (send self ctype)))
    av)
   (:angle-vector-sequence
-   (avs &optional (tms (list 3000)) (ctype controller-type) (start-time 0.1) &key (scale 1) (min-time 0.0) (end-coords-interpolation nil))
+   (avs &optional (tms (list 3000)) (ctype controller-type) (start-time 0.1) &key (scale 1) (min-time 0.0) (end-coords-interpolation nil) (end-coords-interpolation-steps 10))
    "Send sequence of joind angle to robot, this method retuns immediately, so use :wait-interpolation to block until the motion stops.
 - avs: sequence of joint angles(float-vector) [deg],  (list av0 av1 ... avn)
 - tms: sequence of duration(float) from previous angle-vector to next goal [msec],  (list tm0 tm1 ... tmn)
@@ -417,6 +418,7 @@
 - scale : if tms is not specified, it will use 1/scale of the fastest speed
 - min-time : minimum time for time to goal
 - end-coords-interpolation : set t if you want to move robot in cartesian space interpolation
+- end-coords-interpolation-steps : number of divisions when interpolating end-coords
    "
    (setq ctype (or ctype controller-type))  ;; use default controller-type if ctype is nil
    (unless (gethash ctype controller-table)
@@ -443,7 +445,7 @@
              (minjerk (instance minjerk-interpolator :init))
              end-coords-prev end-coords-current ec-prev ec-current
              interpolated-avs interpolated-tms
-             tm i p (ret t)) ;; if nil failed to interpolate
+             tm pass-tm i p (ret t)) ;; if nil failed to interpolate
            ;; set prev-av
          (send robot :angle-vector av-prev)
          (setq end-coords-prev (mapcar #'(lambda (limb) (send robot limb :end-coords :copy-worldcoords)) limbs))
@@ -453,19 +455,21 @@
            (send robot :angle-vector av)
            (setq end-coords-current (mapcar #'(lambda (limb) (send robot limb :end-coords :copy-worldcoords)) limbs))
            (setq target-limbs nil)
+	   (setq tm (elt tms i))
+	   (setq pass-tm (/ tm (float end-coords-interpolation-steps)))
            (dotimes (l (length limbs))
              (setq ec-prev (elt end-coords-prev l) ec-current (elt end-coords-current l))
              (when (and ec-prev ec-current
                         (or (> (norm (send ec-prev :difference-position ec-current)) 1)
                             (> (norm (send ec-prev :difference-rotation ec-current)) (deg2rad 1))))
                (push (elt limbs l) target-limbs)))
-           (send minjerk :reset :position-list (list #f(0) #f(1)) :time-list (list (elt tms i)))
+           (send minjerk :reset :position-list (list #f(0) #f(1)) :time-list (list tm))
            (send robot :angle-vector av-prev)
            (if target-limbs
                (progn
                  (send minjerk :start-interpolation)
-		 (send minjerk :pass-time 100)
-                 (while (progn (send minjerk :pass-time 100) (send minjerk :interpolatingp))
+		 (send minjerk :pass-time pass-tm)
+                 (while (progn (send minjerk :pass-time pass-tm) (send minjerk :interpolatingp))
                    (setq p (elt (send minjerk :position) 0))
                    ;; set midpoint of av as initial pose of IK
                    (send robot :angle-vector (midpoint p av-prev av))
@@ -475,14 +479,14 @@
                      (setq ret (and ret
                                     (send robot limb :inverse-kinematics (midcoords p ec-prev ec-current)))))
                    (push (send robot :angle-vector) interpolated-avs)
-                   (push 100 interpolated-tms)
+                   (push pass-tm interpolated-tms)
                    )
                (push av interpolated-avs)
-               (push 100 interpolated-tms)
+               (push pass-tm interpolated-tms)
 	       )
              (progn
                (push av interpolated-avs)
-               (push (elt tms i) interpolated-tms)))
+               (push tm interpolated-tms)))
            (setq end-coords-prev end-coords-current)
            (setq av-prev av)
            (incf i)) ;; dolist (av avs)

--- a/pr2eus/robot-interface.l
+++ b/pr2eus/robot-interface.l
@@ -438,7 +438,7 @@
        (let ((av-orig (send robot :angle-vector)) ;; initial av, restore at end
              (c-orig  (send robot :copy-worldcoords)) ;; inital coords, restore at end
              (av-prev-orig av-prev) ;; prev-av
-             (limbs '(:larm :rarm :lleg :rleg :torso :head)) ;; defined in https://github.com/euslisp/jskeus/blob/master/irteus/irtrobot.l#L79
+             (limbs '(:larm :rarm :lleg :rleg)) ;; do not move :head and :torso by IK
              target-limbs
              (minjerk (instance minjerk-interpolator :init))
              end-coords-prev end-coords-current ec-prev ec-current
@@ -464,24 +464,25 @@
            (if target-limbs
                (progn
                  (send minjerk :start-interpolation)
-                 (while (send minjerk :interpolatingp)
-                   (send minjerk :pass-time 100)
+		 (send minjerk :pass-time 100)
+                 (while (progn (send minjerk :pass-time 100) (send minjerk :interpolatingp))
                    (setq p (elt (send minjerk :position) 0))
                    ;; set midpoint of av as initial pose of IK
                    (send robot :angle-vector (midpoint p av-prev av))
                    (dolist (limb target-limbs)
-                     ;; don't move arm by IK when interpolation is already ended
-                     (if (>= p 1) (return))
                      (setq ec-prev (elt end-coords-prev (position limb limbs))
                            ec-current (elt end-coords-current (position limb limbs)))
                      (setq ret (and ret
                                     (send robot limb :inverse-kinematics (midcoords p ec-prev ec-current)))))
                    (push (send robot :angle-vector) interpolated-avs)
                    (push 100 interpolated-tms)
-                   ))
+                   )
+               (push av interpolated-avs)
+               (push 100 interpolated-tms)
+	       )
              (progn
                (push av interpolated-avs)
-               (push 50 interpolated-tms)))
+               (push (elt tms i) interpolated-tms)))
            (setq end-coords-prev end-coords-current)
            (setq av-prev av)
            (incf i)) ;; dolist (av avs)


### PR DESCRIPTION
Fixing some problems in :end-coords-interpolation.

Namely,

1. Does not behave properly when over-360 degree turns are present. This is because pr2-interface splits the angle vector in its midpoints, which is not what we want to do in :end-coords-interpolation.

2. Move only in 50 ms when all end-coords are the same.

3. IK usually fails when the head moves. Dealing with it by having :head and :torso move by midpoint vector, instead of IK.

4. It actually does not send designed angle-vector in the end.

5. Solving IK in order may cause arms IK to change desired torso position. Adding :use-torso nil.

This problems can be reproduced with
```
(setq vec #f(50.0 47.7222 12.2897 117.176 -106.014 -77.3995 -76.8709 -105.904 -47.7222 12.2897 -117.176 -106.014 77.3995 -76.8709 105.904 0.0 0.0)
      v0 #f(50.0 53.1894 14.6871 123.249 -121.524 -74.0435 -76.2839 266.776 -53.1894 14.6871 -123.249 -121.524 74.0435 -76.2839 93.2238 0.0 0.0)
      v1 #f(50.0 -16.4077 18.0876 93.6936 -54.8829 77.4245 -30.5008 123.25 -50.4711 19.1116 -59.6967 -13.4894 275.94 -109.525 -35.7734 -47.3098 49.3376)
      v2 #f(191.303 50.0682 17.9701 102.195 -10.7369 43.6391 -103.396 221.198 32.3493 45.9097 -15.2106 -55.9981 227.517 -63.9359 38.9722 0.0 0.0))

;;over 360                                                                                         
(send *ri* :angle-vector-sequence (list vec (send *pr2* :reset-pose)) (list 1000 1000) :default-controller 0 :end-coords-interpolation t)

;;same end-coords                                                                                 
 (send *ri* :angle-vector v0 10000 :default-controller 0 :end-coords-interpolation t)

;;with head movement                                                                               
(send *ri* :angle-vector v1)
(send *ri* :angle-vector v2 2000 :default-controller 0 :end-coords-interpolation t)
```

Captures showing the above code executed on both master branch and after the changes are bellow.
[master](https://drive.google.com/open?id=0B7yBh2Z2PcYOVUVfU2RpQ25QWHM)
[with changes](https://drive.google.com/open?id=0B7yBh2Z2PcYOUVByWlBOUWJhV2M)