### PR TITLE
【robot-interface.l】fix return value of :wait-interpolation for real robot

### DIFF
--- a/pr2eus/robot-interface.l
+++ b/pr2eus/robot-interface.l
@@ -588,14 +588,23 @@
 - timeout : max time of for waiting
 - return values is a list of interpolatingp for all controllers, so (null (some #'identity (send *ri* :wait-interpolation))) -> t if all interpolation has stopped"
    (if (send self :simulation-modep)
-       (while (send self :interpolatingp)
-         (send self :robot-interface-simulation-callback))
-       (cond ;; real robot
-         (ctype
-          (let ((cacts (gethash ctype controller-table)))
-            (send-all cacts :wait-for-result :timeout timeout)))
-         (t (send-all controller-actions :wait-for-result :timeout timeout))))
-   (send-all controller-actions :interpolatingp))
+       (progn
+	 (while (some #'(lambda (a) (send a :interpolatingp)) controller-actions)
+	   (send self :robot-interface-simulation-callback))
+	 (send-all controller-actions :interpolatingp))
+     (cond ;; real robot
+      (ctype
+       (let ((cacts (gethash ctype controller-table)))
+	 (send-all cacts :wait-for-result :timeout timeout)
+	 (mapcar #'(lambda (x)
+		     (not (eq (send x :state) 'ros::*comm-state-done*)))
+		 (send-all cacts :comm-state)
+		 )))
+      (t (progn
+	   (send-all controller-actions :wait-for-result :timeout timeout)
+	   (mapcar #'(lambda (x)
+		       (not (eq (send x :state) 'ros::*comm-state-done*)))
+		   (send-all controller-actions :comm-state)))))))
   (:interpolatingp (&optional (ctype)) ;; controller-type ;; check someone is moving
 "Check if the last sent motion is executing
 return t if interpolating"


### PR DESCRIPTION
https://github.com/jsk-ros-pkg/jsk_pr2eus/pull/191
(null (some #'identity (send *ri* :wait-interpolation))) -> t if all interpolation has stopped
という使い方ができると期待し、
```
(defun touch ()
  ;;armが障害物にぶつかるか、一定距離動くまで動かす関数
  (send *ri* :angle-vector #f(...) 5000)
  (while (some #'identity (send *ri* :wait-interpolation nil 0.1))
    (when (障害物にぶつかった)
      (send *ri* :stop-angle-vector)
      (return-from touch t)))
  nil))
```
としたところ、ループを1周目の前に抜けてしまいました。
原因は、
https://github.com/jsk-ros-pkg/jsk_pr2eus/blob/1d92322c744aecdf8051cfd30da02f1042f1c9e8/pr2eus/robot-interface.l#L598
で:wait-interpolationは(send-all controller-actions :interpolatingp)を返すことになっていますが、
https://github.com/jsk-ros-pkg/jsk_pr2eus/blob/1d92322c744aecdf8051cfd30da02f1042f1c9e8/pr2eus/robot-interface.l#L84
で:interpolatingpはtimer-sequenceを返すことになっており、timer-sequenceはsimulationモード時しか更新されないためです。

(send *ri* :wait-interpolation)はactioncallの/resultが返って来たかどうかを返すのが適切ではないかと考え、コードを修正しました。

なお、(send *ri* :interpolatingp)は、actioncallがサーバー側で受理されてから完了するまでの間tを返す仕様になっているため、:angle-vectorを送った直後はサーバー側から受理されたとの信号がまだ届いておらず、nilを返すようです。