### PR TITLE
Equalize min-time behavior of end-coords-interpolation to usual angle-vector

### DIFF
--- a/pr2eus/robot-interface.l
+++ b/pr2eus/robot-interface.l
@@ -443,6 +443,7 @@
        (ros::ros-warn "length of tms should be the same or smaller than avs")
        (setq tms (subseq tms 0 (length avs)))))
      (when end-coords-interpolation ;; set end-coords interpolation
+       (setq min-time (/ (float min-time) end-coords-interpolation-steps))
        (let ((av-orig (send robot :angle-vector)) ;; initial av, restore at end
              (c-orig  (send robot :copy-worldcoords)) ;; inital coords, restore at end
              (av-prev-orig av-prev) ;; prev-av

--- a/pr2eus/test/default-ri-test.l
+++ b/pr2eus/test/default-ri-test.l
@@ -23,6 +23,14 @@
   (assert (send *ri* :angle-vector (send *robot* :angle-vector) 2000))
   )
 
+(deftest test-end-coords-interpolation
+  (assert (send *robot* :reset-pose))
+  (assert (send *robot* :larm :move-end-pos #f(50 0 0) :world))
+  (assert (send *robot* :rarm :move-end-pos #f(50 0 0) :world))
+  (assert (send *ri* :angle-vector (send *robot* :angle-vector) 1000 nil 0
+                :end-coords-interpolation t))
+  )
+
 (deftest test-wait-interpolation
   (assert (send *robot* :reset-pose))
   (assert (send *ri* :angle-vector (send *robot* :angle-vector) 2000))

--- a/pr2eus/test/pr2-ri-test.l
+++ b/pr2eus/test/pr2-ri-test.l
@@ -225,6 +225,25 @@
     (assert (null ret) "interpolation must be finished")
     ))
 
+(deftest test-end-coords-interpolation
+  (let (tm-0 tm-1 tm-diff)
+    (send *pr2* :reset-manip-pose)
+    (send *ri* :angle-vector (send *pr2* :angle-vector))
+    (send *ri* :wait-interpolation)
+    (send *pr2* :larm :move-end-pos #f(50 0 0) :world)
+    (send *pr2* :rarm :move-end-pos #f(50 0 0) :world)
+    (send *ri* :angle-vector (send *pr2* :angle-vector) 1000 nil 0
+          :min-time 1.0
+          :end-coords-interpolation t
+          :end-coords-interpolation-steps 10)
+    (setq tm-0 (ros::time-now))
+    (send *ri* :wait-interpolation)
+    (setq tm-1 (ros::time-now))
+    (setq tm-diff (send (ros::time- tm-1 tm-0) :to-sec))
+    (ros::ros-info "time for duration ~A" tm-diff)
+    (assert (< tm-diff 2) (format nil "end-coords-interpolation takes too long time ~A" tm-diff))
+    ))
+
 (run-all-tests)
 (exit)
 


### PR DESCRIPTION
Fixes #354 
Includes #378 

cc @Affonso-Gui 