### PR TITLE
euscollada 0.4.0 requries changes in tests

### DIFF
--- a/pr2eus/test/make-pr2-model-file-test.l
+++ b/pr2eus/test/make-pr2-model-file-test.l
@@ -31,13 +31,14 @@
 	  "check number of link"
 	  )
   (mapcar #'(lambda (link-unstable link-stable)
+              (warning-message 3 "unstable ~A~%  stable ~A~%" link-unstable link-stable)
 	      (assert (equal (send link-unstable :name) (send link-stable :name))
 		      (format nil "check link name ~A ~A" (send link-unstable :name) (send link-stable :name)))
 	      (assert
-	       (= (norm (send (send link-unstable :worldcoords) :difference-position (send link-stable :worldcoords))) 0.0)
-	       (format nil "check link position ~A ~A" link-unstable link-stable))
+	       (eps= (norm (send (send link-unstable :worldcoords) :difference-position (send link-stable :worldcoords))) 0.0)
+	       (format nil "check link position ~A ~A" (send link-unstable :worldcoords) (send link-stable :worldcoords)))
 	      (assert
-	       (= (norm (send (send link-unstable :worldcoords) :difference-rotation (send link-stable :worldcoords))) 0.0)
+	       (eps= (norm (send (send link-unstable :worldcoords) :difference-rotation (send link-stable :worldcoords))) 0.0)
 	       (format nil "check link orientation ~A ~A" link-unstable link-stable))
               (unless (eps= (send link-unstable :weight) (send link-stable :weight))
 		(ros::ros-warn "check link weight ~16,12f ~16,12f" (send link-unstable :weight) (send link-unstable :weight)))


### PR DESCRIPTION
I'm afraid euscollada 0.4.0 has some changes on pr2eus test code

c.f. https://github.com/jsk-ros-pkg/jsk_model_tools/pull/216 ? https://github.com/jsk-ros-pkg/jsk_model_tools/pull/212 ?

https://api.travis-ci.org/v3/job/410247467/log.txt

```
[pr2eus.rosunit-make_pr2_model_file_test/test-link][FAILURE]--------------------



                                                                                
Test:(= (norm (send (send link-unstable :worldcoords) :difference-position (send link-stable :worldcoords))) 0.0)



                                                                                
Trace:"^[0mmstart testing [test-link]



                                                                                
vector]



                                                                                
pr2eus/build/pr2eus/test_results/pr2eus/rosunit-make_pr2_model_file_test.xml



                                                                                
"



                                                                                
Message:"check link position #<bodyset-link #X602b028 head_pan_link  -67.07 0.0 1222.125 / 0.0 0.0 0.0> #<bodyset-link #X8da6040 head_pan_link  -67.07 0.0 1222.125 / 0.0 0.0 0.0>"



                                                                                
--------------------------------------------------------------------------------

```