### PR TITLE
Fix :trajectory-filter to ignore start-offset-time

### DIFF
--- a/pr2eus_moveit/euslisp/robot-moveit.l
+++ b/pr2eus_moveit/euslisp/robot-moveit.l
@@ -565,14 +565,14 @@
          (ros::ros-error "Trajectory has very short duration")
          (return-from :angle-vector-motion-plan nil))
        (ros::ros-warn "reset Trajectory Total time")
-       (setq traj (send* self :trajectory-filter traj :start-offset-time start-offset-time :total-time reset-total-time args)))
+       (setq traj (send* self :trajectory-filter traj :total-time reset-total-time args)))
      (ros::ros-info ";; Planned Trajectory Total Time ~7,3f [sec]" orig-total-time)
      (setq total-time
            (cond
              ((eq total-time :fast) (* scale (* orig-total-time 1000)))
              ((or (null total-time) (> orig-total-time (/ total-time 1000.0))) (* orig-total-time 1000))
              (t total-time)))
-     (setq traj (send* self :trajectory-filter traj :start-offset-time start-offset-time :total-time total-time args))
+     (setq traj (send* self :trajectory-filter traj :total-time total-time args))
      (ros::ros-info ";; Scaled Trajectory Total Time ~0,3f(~0,3f) [sec]" (send (send (car (last (send traj :joint_trajectory :points))) :time_from_start) :to-sec) (/ total-time 1000.0))
      (ros::ros-info ";; generated ~A points for ~A sec using [~A] group" (length (send traj :joint_trajectory :points)) (/ total-time 1000.0) (send ret :group_name))
      (ros::ros-info ";; will send to ~A" (send traj :joint_trajectory :joint_names))

--- a/pr2eus_moveit/euslisp/robot-moveit.l
+++ b/pr2eus_moveit/euslisp/robot-moveit.l
@@ -626,12 +626,11 @@
          (send* self :send-trajectory (send traj :joint_trajectory) args))
      ret))
   (:trajectory-filter ;; simple trajectory for zero duration
-   (traj &key (copy) (total-time 5000.0) (start-offset-time 0) (clear-velocities) &rest args &allow-other-keys)
+   (traj &key (copy) (total-time 5000.0) (clear-velocities) &rest args &allow-other-keys)
    "traj (moveit_msgs/RobotTrajectory): input trajectory"
    (let ((orig-total-time (send (send (car (last (send traj :joint_trajectory :points))) :time_from_start) :to-sec)))
      ;; check if valid filtering can be applied
-     (when (or (null start-offset-time)
-               (null total-time))
+     (when (null total-time)
        (ros::ros-debug ";; Trajectory filter is skipped")
        (return-from :trajectory-filter traj))
 
@@ -646,12 +645,12 @@
          (when clear-velocities
            (send pt :velocities #f())
            (send pt :accelerations #f()))
-         (send pt :time_from_start (ros::time (+ start-offset-time (* time-scale (send (send pt :time_from_start) :to-sec))))))
+         (send pt :time_from_start (ros::time (* time-scale (send (send pt :time_from_start) :to-sec)))))
        (dolist (pt mdof-points)
          (when clear-velocities
            (send pt :velocities nil)
            (send pt :accelerations nil))
-         (send pt :time_from_start (ros::time (+ start-offset-time (* time-scale (send (send pt :time_from_start) :to-sec)))))))
+         (send pt :time_from_start (ros::time (* time-scale (send (send pt :time_from_start) :to-sec))))))
        traj))
   ) ;; robot-interface
 

--- a/pr2eus_moveit/test/test-pr2eus-moveit.l
+++ b/pr2eus_moveit/test/test-pr2eus-moveit.l
@@ -145,6 +145,22 @@
     (assert (> tm-diff 3) (format nil "collsion avoidance motion is too fast ~A" tm-diff))
     ))
 
+;; send angle-vector with start-offset-time
+(deftest test-start-offset-time ()
+  (let (tm-0 tm-1 tm-diff)
+    (send *ri* :angle-vector (send *pr2* :reset-pose))
+    (send *ri* :wait-interpolation)
+    (send *pr2* :rarm :move-end-pos #f(100 0 0) :world)
+    (send *ri* :angle-vector-motion-plan (send *pr2* :angle-vector) :start-offset-time 4 :total-time 2000 :move-arm :rarm :use-torso nil)
+    (setq tm-0 (ros::time-now))
+    (send *ri* :wait-interpolation)
+    (setq tm-1 (ros::time-now))
+    (setq tm-diff (send (ros::time- tm-1 tm-0) :to-sec))
+    (ros::ros-info "time for duration ~A" tm-diff)
+    (assert (> tm-diff 5) (format nil "start-offset-time is ignored. Traj finishes at ~A" tm-diff))
+    (assert (< tm-diff 7) (format nil "start-offset-time is considered multiple times. Traj finishes at ~A" tm-diff))
+    ))
+
 (run-all-tests)
 (exit)
 


### PR DESCRIPTION
Include #373 

`start-offset-time` should only affect time stamp of trajectory, which is set in `:send-trajectory`.
We don't need to set it in `trajectory-filter`.

- Current state without this PR:
Total time of trajectory becomes `start-offset-time`[s] + `total-time`[ms].
The execution of first trajectory point takes original `time_from_start` + `start-offset-time`.
As `start-offset-time` also affects time stamp of trajectory, trajectory finishes `start-offset-time` * 2 + `total-time` after calling `:angle-vector-motion-plan`.
```
3.irteusgl$ send *ri* :angle-vector-motion-plan (send *baxter* :angle-vector) :start-offset-time 5 :total-time 1000 :ctype :default-controller :move-arm :arms :clear-velocities t
[ INFO] [1534232819.952439981]: [/default_robot_interface_1534232610481270195] [ROSEUS_ROSINFO] ;; Planned Trajectory Total Time   0.887 [sec]
[ INFO] [1534232819.952852500]: [/default_robot_interface_1534232610481270195] [ROSEUS_ROSINFO] ;; Scaled Trajectory Total Time 6.000(1.000) [sec]
[ INFO] [1534232819.952914714]: [/default_robot_interface_1534232610481270195] [ROSEUS_ROSINFO] ;; generated 10 points for 1.0 sec using [both_arms] group
[ INFO] [1534232819.952971371]: [/default_robot_interface_1534232610481270195] [ROSEUS_ROSINFO] ;; will send to (left_s0 left_s1 left_e0 left_e1 left_w0 left_w1 left_w2 left_gripper_prismatic_joint left_gripper_vacuum_pad_joint right_s0 right_s1 right_e0 right_e1 right_w0 right_w1 right_w2 right_gripper_prismatic_joint right_gripper_vacuum_pad_joint)
[ INFO] [1534232819.953208033]: [/default_robot_interface_1534232610481270195] [ROSEUS_ROSINFO] ;; send self :angle-vector :head-controller (#<controller-action-client #Xeefbd78 /robot/head/head_action>) (without planning)
;; #<rotational-joint #Xb3ccd50 right_gripper_finger_roll_joint> :joint-angle(-0.078983) violate min-angle(0.0)
;; #<rotational-joint #Xb3cd008 right_gripper_finger_yaw_joint> :joint-angle(-0.225361) violate min-angle(0.0)
[ INFO] [1534232819.975442103]: [/default_robot_interface_1534232610481270195] [ROSEUS_ROSINFO] ;; send self :send-trajectory :default-controller
#<moveit_msgs::motionplanresponse #Xf180c20>
```