### PR TITLE
Fix time_from_start in motion-planned angle-vector-sequence

### DIFF
--- a/pr2eus_moveit/euslisp/robot-moveit.l
+++ b/pr2eus_moveit/euslisp/robot-moveit.l
@@ -535,10 +535,10 @@
               (send ret :trajectory :joint_trajectory :points points))
           (if (send ret :trajectory :multi_dof_joint_trajectory)
               (nconc (send ret :trajectory :multi_dof_joint_trajectory :points) mdof-points)
-              (send ret :trajectory :multi_dof_joint_trajectory :points mdof-points))
-          (send robot :angle-vector tmp-av)))
+              (send ret :trajectory :multi_dof_joint_trajectory :points mdof-points))))
        (setq time-from-start
-             (send (send (car (last points)) :time_from_start) :to-sec)))
+             (send (send (car (last points)) :time_from_start) :to-sec))
+       (send robot :angle-vector tmp-av))
      ret))
   (:end-coords-make-trajectory (cds &rest args)
    (let* ((r (send* self :parse-end-coords args))

--- a/pr2eus_moveit/euslisp/robot-moveit.l
+++ b/pr2eus_moveit/euslisp/robot-moveit.l
@@ -512,12 +512,12 @@
                     :end-coords ed-lst args))
        (unless tmp-ret
          (return-from :angle-vector-make-trajectory nil))
+       (setq points (send tmp-ret :trajectory :joint_trajectory :points))
        (cond
          ((null ret)
           (setq ret tmp-ret))
          (t
-          (setq points (send tmp-ret :trajectory :joint_trajectory :points)
-                mdof-points (send tmp-ret :trajectory :multi_dof_joint_trajectory :points))
+          (setq mdof-points (send tmp-ret :trajectory :multi_dof_joint_trajectory :points))
           (when time-from-start
             (dolist (pt points)
               (send pt :time_from_start
@@ -536,9 +536,9 @@
           (if (send ret :trajectory :multi_dof_joint_trajectory)
               (nconc (send ret :trajectory :multi_dof_joint_trajectory :points) mdof-points)
               (send ret :trajectory :multi_dof_joint_trajectory :points mdof-points))
-          (setq time-from-start
-                (send (send (car (last points)) :time_from_start) :to-sec))
-          (send robot :angle-vector tmp-av))))
+          (send robot :angle-vector tmp-av)))
+       (setq time-from-start
+             (send (send (car (last points)) :time_from_start) :to-sec)))
      ret))
   (:end-coords-make-trajectory (cds &rest args)
    (let* ((r (send* self :parse-end-coords args))

--- a/pr2eus_moveit/test/test-pr2eus-moveit.l
+++ b/pr2eus_moveit/test/test-pr2eus-moveit.l
@@ -99,7 +99,7 @@
     (setq tm-list (mapcar #'(lambda (pt) (send (send pt :time_from_start) :to-sec))
                           (send motion-plan-res :trajectory :joint_trajectory :points)))
     (setq sorted-tm-list (copy-object tm-list))
-    (sort sorted-tm-list #'<)
+    (sort sorted-tm-list #'<=)
     (assert (equal tm-list sorted-tm-list) "time_from_start is not arranged in ascending order")
     ))
 

--- a/pr2eus_moveit/test/test-pr2eus-moveit.l
+++ b/pr2eus_moveit/test/test-pr2eus-moveit.l
@@ -90,6 +90,19 @@
 ;; setup moveit interface
 (send *ri* :set-moveit-environment (instance pr2-moveit-environment :init))
 
+;; test concatenation of moveit response in angle-vector-make-trajectory
+(deftest test-avs-to-angle-vector-make-trajectory ()
+  (let (motion-plan-res tm-list sorted-tm-list)
+    (setq motion-plan-res (send *ri* :angle-vector-make-trajectory
+                                (list (send *pr2* :reset-manip-pose) (send *pr2* :reset-pose))
+                                :move-arm :rarm :use-torso t))
+    (setq tm-list (mapcar #'(lambda (pt) (send (send pt :time_from_start) :to-sec))
+                          (send motion-plan-res :trajectory :joint_trajectory :points)))
+    (setq sorted-tm-list (copy-object tm-list))
+    (sort sorted-tm-list #'<)
+    (assert (equal tm-list sorted-tm-list) "time_from_start is not arranged in ascending order")
+    ))
+
 ;; send angle-vector with collision avoidance
 (deftest test-angle-vector-motion-plan ()
   (let (av-diff)


### PR DESCRIPTION
Include #372 

When I use `:angle-vector-motion-plan` in pr2eus_moveit with list of two angle-vectors, the last angle-vector is skipped.
This is because trajectory points for second angle-vector starts from `time_from_start: 0` again.
I add test to detect this bug and fix.
```
$ rostopic echo /robot/limb/left/follow_joint_trajectory/goal 
header: 
  seq: 1
  stamp: 
    secs: 1534242824
    nsecs: 729660623
  frame_id: ''
goal_id: 
  stamp: 
    secs: 0
    nsecs:         0
  id: 1534242820729731921_/default_robot_interface_1534239753379624356_80342_/robot/limb/left/follow_joint_trajectory_12
goal: 
  trajectory: 
    header: 
      seq: 1
      stamp: 
        secs: 1534242824
        nsecs: 729660623
      frame_id: ''
    joint_names: ['left_s0', 'left_s1', 'left_e0', 'left_e1', 'left_w0', 'left_w1', 'left_w2']
    points: 
      - 
        positions: [1.2676694342046062, 0.6743298063427532, -1.9387100136411437, 2.103555420218015, 1.6277475880211183, 0.6973072658200672, 0.3449746277554351]
        velocities: []
        accelerations: []
        effort: []
        time_from_start: 
          secs: 0
          nsecs:         0
      - 
        positions: [1.2172655913958197, 0.6572224481698226, -1.9436173999322994, 2.0632726139582402, 1.6479222227612684, 0.6763317184891946, 0.3307340925707729]
        velocities: []
        accelerations: []
        effort: []
        time_from_start: 
          secs: 0
          nsecs: 505630592
      - 
        positions: [1.1668617485870332, 0.6401150899968919, -1.9485247862234552, 2.022989807698467, 1.6680968575014194, 0.655356171158322, 0.31649355738611074]
        velocities: []
        accelerations: []
        effort: []
        time_from_start: 
          secs: 0
          nsecs: 786699648
      - 
        positions: [1.1164579057782467, 0.6230077318239613, -1.9534321725146109, 1.9827070014386932, 1.6882714922415705, 0.6343806238274494, 0.3022530222014488]
        velocities: []
        accelerations: []
        effort: []
        time_from_start: 
          secs: 1
          nsecs:   7248274
      - 
        positions: [1.0660540629694601, 0.6059003736510307, -1.9583395588057666, 1.94242419517892, 1.7084461269817206, 0.6134050764965773, 0.2880124870167866]
        velocities: []
        accelerations: []
        effort: []
        time_from_start: 
          secs: 1
          nsecs: 194048192
      - 
        positions: [1.0156502201606736, 0.5887930154781, -1.9632469450969223, 1.902141388919146, 1.7286207617218716, 0.5924295291657047, 0.27377195183212466]
        velocities: []
        accelerations: []
        effort: []
        time_from_start: 
          secs: 1
          nsecs: 368279872
      - 
        positions: [0.9652463773518876, 0.5716856573051694, -1.968154331388078, 1.861858582659372, 1.7487953964620226, 0.5714539818348321, 0.2595314166474625]
        velocities: []
        accelerations: []
        effort: []
        time_from_start: 
          secs: 1
          nsecs: 566571712
      - 
        positions: [0.914842534543101, 0.5545782991322388, -1.9730617176792338, 1.821575776399599, 1.7689700312021737, 0.55047843450396, 0.24529088146280043]
        velocities: []
        accelerations: []
        effort: []
        time_from_start: 
          secs: 1
          nsecs: 802080448
      - 
        positions: [0.864438691734315, 0.5374709409593086, -1.9779691039703895, 1.781292970139825, 1.7891446659423238, 0.5295028871730874, 0.23105034627813836]
        velocities: []
        accelerations: []
        effort: []
        time_from_start: 
          secs: 2
          nsecs:  90522864
      - 
        positions: [0.8140348489255285, 0.520363582786378, -1.9828764902615452, 1.741010163880051, 1.8093193006824748, 0.5085273398422148, 0.2168098110934763]
        velocities: []
        accelerations: []
        effort: []
        time_from_start: 
          secs: 2
          nsecs: 795480128
      - 
        positions: [1.2676694342046062, 0.6743298063427532, -1.9387100136411437, 2.103555420218015, 1.6277475880211183, 0.6973072658200672, 0.3449746277554351]
        velocities: []
        accelerations: []
        effort: []
        time_from_start: 
          secs: 0
          nsecs:         0
      - 
        positions: [1.2423574631617704, 0.6652541935634759, -1.939909558574854, 2.0866015952675863, 1.6422025190881504, 0.685373737796175, 0.33342358423911933]
        velocities: []
        accelerations: []
        effort: []
        time_from_start: 
          secs: 0
          nsecs: 361213152
      - 
        positions: [1.2170454921189338, 0.6561785807841987, -1.9411091035085644, 2.0696477703171574, 1.6566574501551825, 0.6734402097722834, 0.3218725407228038]
        velocities: []
        accelerations: []
        effort: []
        time_from_start: 
          secs: 0
          nsecs: 560700096
      - 
        positions: [1.191733521076098, 0.6471029680049214, -1.9423086484422756, 2.0526939453667286, 1.6711123812222155, 0.6615066817483917, 0.3103214972064883]
        velocities: []
        accelerations: []
        effort: []
        time_from_start: 
          secs: 0
          nsecs: 714979456
      - 
        positions: [1.1664215500332622, 0.6380273552256441, -1.943508193375986, 2.0357401204162997, 1.6855673122892476, 0.6495731537245, 0.29877045369017274]
        velocities: []
        accelerations: []
        effort: []
        time_from_start: 
          secs: 0
          nsecs: 847867840
      - 
        positions: [1.1411095789904264, 0.6289517424463673, -1.9447077383096962, 2.018786295465871, 1.7000222433562797, 0.6376396257006083, 0.287219410173857]
        velocities: []
        accelerations: []
        effort: []
        time_from_start: 
          secs: 0
          nsecs: 970588032
      - 
        positions: [1.1157976079475906, 0.61987612966709, -1.9459072832434066, 2.001832470515442, 1.7144771744233127, 0.6257060976767166, 0.27566836665754146]
        velocities: []
        accelerations: []
        effort: []
        time_from_start: 
          secs: 1
          nsecs: 110255104
      - 
        positions: [1.0904856369047549, 0.6108005168878128, -1.9471068281771178, 1.984878645565014, 1.7289321054903448, 0.6137725696528249, 0.26411732314122593]
        velocities: []
        accelerations: []
        effort: []
        time_from_start: 
          secs: 1
          nsecs: 277127232
      - 
        positions: [1.065173665861919, 0.6017249041085355, -1.948306373110828, 1.9679248206145852, 1.7433870365573778, 0.6018390416289332, 0.2525662796249104]
        velocities: []
        accelerations: []
        effort: []
        time_from_start: 
          secs: 1
          nsecs: 501095296
      - 
        positions: [1.0398616948190833, 0.5926492913292583, -1.9495059180445384, 1.9509709956641563, 1.75784196762441, 0.5899055136050411, 0.24101523610859477]
        velocities: []
        accelerations: []
        effort: []
        time_from_start: 
          secs: 2
          nsecs:         0
  path_tolerance: []
  goal_tolerance: []
  goal_time_tolerance: 
    secs: 0
    nsecs:         0
---
```