### PR TITLE
Add end-coords-interpolation test

### DIFF
--- a/pr2eus/test/default-ri-test.l
+++ b/pr2eus/test/default-ri-test.l
@@ -23,6 +23,14 @@
   (assert (send *ri* :angle-vector (send *robot* :angle-vector) 2000))
   )
 
+(deftest test-end-coords-interpolation
+  (assert (send *robot* :reset-pose))
+  (assert (send *robot* :larm :move-end-pos #f(50 0 0) :world))
+  (assert (send *robot* :rarm :move-end-pos #f(50 0 0) :world))
+  (assert (send *ri* :angle-vector (send *robot* :angle-vector) 1000 nil 0
+                :end-coords-interpolation t))
+  )
+
 (deftest test-wait-interpolation
   (assert (send *robot* :reset-pose))
   (assert (send *ri* :angle-vector (send *robot* :angle-vector) 2000))

--- a/pr2eus/test/pr2-ri-test.l
+++ b/pr2eus/test/pr2-ri-test.l
@@ -225,6 +225,25 @@
     (assert (null ret) "interpolation must be finished")
     ))
 
+(deftest test-end-coords-interpolation
+  (let (tm-0 tm-1 tm-diff)
+    (send *pr2* :reset-manip-pose)
+    (send *ri* :angle-vector (send *pr2* :angle-vector))
+    (send *ri* :wait-interpolation)
+    (send *pr2* :larm :move-end-pos #f(50 0 0) :world)
+    (send *pr2* :rarm :move-end-pos #f(50 0 0) :world)
+    (send *ri* :angle-vector (send *pr2* :angle-vector) 1000 nil 0
+          :min-time 1.0
+          :end-coords-interpolation t
+          :end-coords-interpolation-steps 10)
+    (setq tm-0 (ros::time-now))
+    (send *ri* :wait-interpolation)
+    (setq tm-1 (ros::time-now))
+    (setq tm-diff (send (ros::time- tm-1 tm-0) :to-sec))
+    (ros::ros-info "time for duration ~A" tm-diff)
+    (assert (< tm-diff 2) (format nil "end-coords-interpolation takes too long time ~A" tm-diff))
+    ))
+
 (run-all-tests)
 (exit)
 


### PR DESCRIPTION
Included in #355 
- Add simple test to avoid eus error in `:angle-vector` with `:end-coords-interpolation t`
- Add test to catch #354 

Travis of this PR will fail due to the latter test.