### PR TITLE
Fix confirmation on warningp

### DIFF
--- a/pr2eus/robot-interface.l
+++ b/pr2eus/robot-interface.l
@@ -722,7 +722,7 @@ Return value is a list of interpolatingp for all controllers, so (null (some #'i
    (when (send self :simulation-modep)
      (return-from :send-ros-controller nil))
    (if (and warningp
-	    (yes-or-no-p (format nil "~C[3~CmAre you sure to move the real robot? (~A) ~C[0m" #x1b 49 (send action :name) #x1b)))
+	    (not (yes-or-no-p (format nil "~C[3~CmAre you sure to move the real robot? (~A) ~C[0m" #x1b 49 (send action :name) #x1b))))
        (return-from :send-ros-controller nil))
    (let* ((goal (send action :make-goal-instance))
 	  (goal-points nil)


### PR DESCRIPTION
Apparently we can reproduce the confirmation behavior of the (unused)`:angle-vector-safe` by setting the (even more unused) `warningp` flag. By doing so, when about to move the real robot a confirmation prompt pops out asking if that is really what we want.

However, when using the `warningp` this prompt is inverted, so saying that you do NOT want the robot to move make it move:

```lisp
(send *ri* :warningp t)
(send *ri* :angle-vector (send *pr2* :init-pose) 5000)
Are you sure to move the real robot? (l_arm_controller/follow_joint_trajectory) (YES or NO): no
Are you sure to move the real robot? (r_arm_controller/follow_joint_trajectory) (YES or NO): no
Are you sure to move the real robot? (head_traj_controller/follow_joint_trajectory) (YES or NO): no
Are you sure to move the real robot? (torso_controller/follow_joint_trajectory) (YES or NO): no

;; ROBOT MOVES
```