### PR TITLE
Fix return value of clear-costmap function

### DIFF
--- a/pr2eus/robot-interface.l
+++ b/pr2eus/robot-interface.l
@@ -1744,8 +1744,11 @@ Return value is a list of interpolatingp for all controllers, so (null (some #'i
    "Send signal to clear costmap for obstacle avoidance to move_base."
    (let ((srv-name (format nil "~A/clear_costmaps" (send move-base-action :name))))
      (if (ros::wait-for-service srv-name 0)
-         (call-empty-service srv-name)))
-   t)
+         (progn
+           (call-empty-service srv-name)
+           t)
+         nil))
+   )
   (:change-inflation-range
    (&optional (range 0.2)
     &key (node-name "/move_base_node")
@@ -1880,13 +1883,16 @@ Return value is a list of interpolatingp for all controllers, so (null (some #'i
 
 (defun clear-costmap (&key (node-name "/move_base_node"))
   "reset local costmap and clear unknown grid around robot"
-  (if (and (boundp '*ri*) (derivedp *ri* robot-move-base-interface))
-      (send *ri* :clear-costmap)
+  (if (and (and (boundp '*ri*) (derivedp *ri* robot-move-base-interface))
+           (send *ri* :clear-costmap))
+      t
       ;; for backward compatibility
       (let ((srv-name (format nil "/~A/clear_costmaps" node-name)))
         (if (ros::wait-for-service srv-name 0)
-            (call-empty-service srv-name))))
-  t)
+            (progn
+              (call-empty-service srv-name)
+              t)
+            nil))))
 
 (defun change-inflation-range (&optional (range 0.2)
                                          &key (node-name "/move_base_node")

--- a/pr2eus/robot-interface.l
+++ b/pr2eus/robot-interface.l
@@ -1741,10 +1741,9 @@ Return value is a list of interpolatingp for all controllers, so (null (some #'i
    )
   (:clear-costmap
    ()
-   "Send signal to clear costmap for obstacle avoidance to move_base."
+   "Send signal to clear costmap for obstacle avoidance to move_base and return t if succeeded."
    (let ((srv-name (format nil "~A/clear_costmaps" (send move-base-action :name))))
-     (if (ros::wait-for-service srv-name 0)
-         (call-empty-service srv-name)))
+     (call-empty-service srv-name))
    )
   (:change-inflation-range
    (&optional (range 0.2)
@@ -1879,14 +1878,13 @@ Return value is a list of interpolatingp for all controllers, so (null (some #'i
 ;;
 
 (defun clear-costmap (&key (node-name "/move_base_node"))
-  "reset local costmap and clear unknown grid around robot"
+  "reset local costmap, clear unknown grid around robot and return t if succeeded"
   (if (and (and (boundp '*ri*) (derivedp *ri* robot-move-base-interface))
            (send *ri* :clear-costmap))
       t
       ;; for backward compatibility
       (let ((srv-name (format nil "/~A/clear_costmaps" node-name)))
-        (if (ros::wait-for-service srv-name 0)
-            (call-empty-service srv-name)))))
+        (call-empty-service srv-name))))
 
 (defun change-inflation-range (&optional (range 0.2)
                                          &key (node-name "/move_base_node")

--- a/pr2eus/robot-interface.l
+++ b/pr2eus/robot-interface.l
@@ -1744,10 +1744,7 @@ Return value is a list of interpolatingp for all controllers, so (null (some #'i
    "Send signal to clear costmap for obstacle avoidance to move_base."
    (let ((srv-name (format nil "~A/clear_costmaps" (send move-base-action :name))))
      (if (ros::wait-for-service srv-name 0)
-         (progn
-           (call-empty-service srv-name)
-           t)
-         nil))
+         (call-empty-service srv-name)))
    )
   (:change-inflation-range
    (&optional (range 0.2)
@@ -1889,10 +1886,7 @@ Return value is a list of interpolatingp for all controllers, so (null (some #'i
       ;; for backward compatibility
       (let ((srv-name (format nil "/~A/clear_costmaps" node-name)))
         (if (ros::wait-for-service srv-name 0)
-            (progn
-              (call-empty-service srv-name)
-              t)
-            nil))))
+            (call-empty-service srv-name)))))
 
 (defun change-inflation-range (&optional (range 0.2)
                                          &key (node-name "/move_base_node")


### PR DESCRIPTION
`clear-costmap` function and `:clear-costmap` method, whose namespace was fixed in #343, always return `t` even if a service call failed.
In this PR the function returns `t` after calling that service, and otherwise (if the service is not advertised yet) returns `nil`.