### PR TITLE
fixed go-stop for robots that don't have move-base-trajectory-action

### DIFF
--- a/pr2eus/robot-interface.l
+++ b/pr2eus/robot-interface.l
@@ -1284,9 +1284,11 @@ Return value is a list of interpolatingp for all controllers, so (null (some #'i
   (:go-stop (&optional (force-stop t))
    (when joint-action-enable
      (send move-base-action :cancel-all-goals)
-     (prog1
-         (send move-base-trajectory-action :cancel-all-goals)
-       (if force-stop (send self :go-velocity 0 0 0)))
+     (when move-base-trajectory-action
+       (prog1
+           (send move-base-trajectory-action :cancel-all-goals)
+         (if force-stop (send self :go-velocity 0 0 0)))
+       )
      ))
 
   (:make-plan

--- a/pr2eus/robot-interface.l
+++ b/pr2eus/robot-interface.l
@@ -1285,10 +1285,9 @@ Return value is a list of interpolatingp for all controllers, so (null (some #'i
    (when joint-action-enable
      (send move-base-action :cancel-all-goals)
      (when move-base-trajectory-action
-       (prog1
-           (send move-base-trajectory-action :cancel-all-goals)
-         (if force-stop (send self :go-velocity 0 0 0)))
-       )
+       ;; some robots (e.g. fetch) don't have move-base-trajectory-action
+       (send move-base-trajectory-action :cancel-all-goals))
+     (if force-stop (send self :go-velocity 0 0 0))
      ))
 
   (:make-plan


### PR DESCRIPTION
In the previous code, method :cancel-all-goals is called for all robots. However, for example in fetch robot case, move-base-trajectory-action is set to nil (see [here](https://github.com/jsk-ros-pkg/jsk_robot/blob/master/jsk_fetch_robot/fetcheus/fetch-interface.l#L17) and [here](https://github.com/jsk-ros-pkg/jsk_pr2eus/blob/master/pr2eus/robot-interface.l#L1258)), so if one use :go-stop for the fetch robot, one will get the following error:
`
/opt/ros/kinetic/share/euslisp/jskeus/eus/Linux64/bin/irteusgl 0 error: cannot find method :cancel-all-goals in (send move-base-trajectory-action :cancel-all-goals)`

By this pull-request, :go-stop can be used for robots which don't have `move-base-trajectory-action` such as fetch.