### PR TITLE
Updates to :stop-motion

### DIFF
--- a/pr2eus/robot-interface.l
+++ b/pr2eus/robot-interface.l
@@ -626,6 +626,7 @@ return t if interpolating"
              (setq cacts (gethash ctype controller-table)))
             (t
              (setq cacts controller-actions)))
+      (send self :spin-once)  ;; update interpolatingp
       (some #'(lambda (a) (send a :interpolatingp)) cacts)))
   (:wait-interpolation-smooth (time-to-finish &optional (ctype))
 "Return time-to-finish [msec] before the sent command is finished. Example code are:
@@ -667,9 +668,10 @@ Return value is a list of interpolatingp for all controllers, so (null (some #'i
             (send-all controller-actions :time-to-finish)))))
   (:stop-motion (&key (stop-time 0))
    "Stop current executing motion"
-   (let ((av (send self :state :potentio-vector)))
-     (send self :angle-vector av stop-time)
-     (send self :wait-interpolation)))
+   (when (send self :interpolatingp)
+     (let ((av (send self :state :potentio-vector)))
+       (send self :angle-vector av stop-time)
+       (send self :wait-interpolation))))
   (:cancel-angle-vector
    (&key ((:controller-actions ca))
          ((:controller-type ct))

--- a/pr2eus/robot-interface.l
+++ b/pr2eus/robot-interface.l
@@ -666,12 +666,14 @@ Return value is a list of interpolatingp for all controllers, so (null (some #'i
               (send-all cacts :time-to-finish)))
            (t
             (send-all controller-actions :time-to-finish)))))
-  (:stop-motion (&key (stop-time 0))
+  (:stop-motion (&key (stop-time 0) (wait t))
    "Stop current executing motion"
    (when (send self :interpolatingp)
      (let ((av (send self :state :potentio-vector)))
        (send self :angle-vector av stop-time)
-       (send self :wait-interpolation))))
+       (if wait
+           (send self :wait-interpolation)
+           t))))
   (:cancel-angle-vector
    (&key ((:controller-actions ca))
          ((:controller-type ct))

--- a/pr2eus/robot-interface.l
+++ b/pr2eus/robot-interface.l
@@ -667,7 +667,7 @@ Return value is a list of interpolatingp for all controllers, so (null (some #'i
            (t
             (send-all controller-actions :time-to-finish)))))
   (:stop-motion (&key (stop-time 0) (wait t))
-   "Smoothly stops the motion being executed by sending the current joint state to the joint trajectory action goal"
+   "Smoothly stops the motion being executed by sending the current joint state to the joint trajectory action goal in stop-time [ms]. Please note that if stop-time is smaller than the :angle-vector min-time (defaulting to 1000 [ms]) the actual interpolation uses min-time instead. Refer to :cancel-angle-vector for a faster stop"
    (when (send self :interpolatingp)
      (let ((av (send self :state :potentio-vector)))
        (send self :angle-vector av stop-time)

--- a/pr2eus/robot-interface.l
+++ b/pr2eus/robot-interface.l
@@ -667,7 +667,7 @@ Return value is a list of interpolatingp for all controllers, so (null (some #'i
            (t
             (send-all controller-actions :time-to-finish)))))
   (:stop-motion (&key (stop-time 0) (wait t))
-   "Stop current executing motion"
+   "Smoothly stops the motion being executed by sending the current joint state to the joint trajectory action goal"
    (when (send self :interpolatingp)
      (let ((av (send self :state :potentio-vector)))
        (send self :angle-vector av stop-time)
@@ -678,7 +678,7 @@ Return value is a list of interpolatingp for all controllers, so (null (some #'i
    (&key ((:controller-actions ca))
          ((:controller-type ct))
          (wait))
-   "Cancel current joint trajectory action"
+   "Cancels the current joint trajectory action, causing an abrupt stop"
    (when (null (or ca ct)) (setq ca controller-actions))
    (when ca (send-all ca :cancel-all-goals))
    (when ct (send-all (gethash ct controller-table) :cancel-all-goals))


### PR DESCRIPTION
The `:stop-motion` stops the current angle vector by sending the actual angle vector as a new command (and therefore overwriting the old command).

The problem is that is also does that when there is no ongoing action, and since it also have an `:wait-interpolation` it takes a few seconds to return from the call.

In this PR we:
1. Only overwrite commands when there are ongoing actions
1. Add a `wait` key argument to the `:stop-motion`, so the user can opt not to wait-interpolation.

@pazeshun 