### PR TITLE
use map frame for :state :worldcoords

### DIFF
--- a/pr2eus/pr2-interface.l
+++ b/pr2eus/pr2-interface.l
@@ -90,7 +90,7 @@
      (:worldcoords
       (unless joint-action-enable
 	(return-from :state (send self :worldcoords)))
-      (send-super :state :worldcoords (or (cadr args) "world")))
+      (send-super :state :worldcoords (or (cadr args) "map")))
      (t
       (send-super* :state args))
      ))


### PR DESCRIPTION
`pr2-interface.l` uses `world` coords for `:state :worldcoords` (instead `robot-interface` uses `map` coords for `:state :worldcoords`)
I update to use `map` for `:state :worldcoords`
