### PR TITLE
Increase number of jobs during 'catkin run_tests'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ env:
     - secure: "REUwDilheEXGFShSdFNgQ1rRAFBw2QG2eT8XDAQsDFyhPfCnjGDA1Ak25TbVIz4a02M9/hDP4QtsXFj6VRHVs4tV55zrGeLea06+Fw8vjHEICYVtfzYYvZB3pHnWoxxPUcQTU+CgTMGV3lLSupMgvyNNY8J6UdaiW8+Oj7icHc4="
     - ROSWS=wstool
     - BUILDER=catkin
-    - CATKIN_PARALLEL_TEST_JOBS="-j1 -p1"
-    - ROS_PARALLEL_TEST_JOBS="-j1"
+    - CATKIN_PARALLEL_TEST_JOBS="-j4 -p1"
+    - ROS_PARALLEL_TEST_JOBS="-j4"
     - USE_DOCKER=true
   matrix:
     - ROS_DISTRO=indigo  USE_DEB=true EXTRA_DEB="ros-indigo-pr2-gazebo ros-indigo-pr2-arm-kinematics"


### PR DESCRIPTION
Travis test is failing because of timeout (50min) recently (e.g. PR #402, #408, #412, etc., and even on current master branch).
I hope those PRs will pass test with this PR.