### PR TITLE
[pr2eus_moveit] replace code with functions to create shape_msgs::SolidPrimitive

### DIFF
--- a/pr2eus_moveit/euslisp/collision-object-publisher.l
+++ b/pr2eus_moveit/euslisp/collision-object-publisher.l
@@ -62,11 +62,7 @@
          (send colobj :primitives
                (append geom
                        (list
-                        (instance shape_msgs::SolidPrimitive
-                                  :init :type shape_msgs::SolidPrimitive::*CYLINDER*
-                                  :dimensions (float-vector
-                                               (/ (height-of-cylinder obj) 1000.0)
-                                               (/ (radius-of-cylinder obj) 1000.0))))))
+                        (cylinder->shape-msg obj))))
          (send colobj :primitive_poses
                (append pose
                        (list
@@ -77,12 +73,7 @@
          (send colobj :primitives
                (append geom
                        (list
-                        (instance shape_msgs::SolidPrimitive
-                                  :init :type shape_msgs::SolidPrimitive::*BOX*
-                                  :dimensions (float-vector
-                                               (/ (elt (send obj :body-type) 1) 1000.0)
-                                               (/ (elt (send obj :body-type) 2) 1000.0)
-                                               (/ (elt (send obj :body-type) 3) 1000.0))))))
+                        (cube->shape-msg obj))))
          (send colobj :primitive_poses
                (append pose
                        (list
@@ -93,10 +84,7 @@
          (send colobj :primitives
                (append geom
                        (list
-                        (instance shape_msgs::SolidPrimitive
-                                  :init :type shape_msgs::SolidPrimitive::*SPHERE*
-                                  :dimensions (float-vector
-                                               (/ (radius-of-sphere obj) 1000.0))))))
+                        (sphere->shape-msg obj))))
          (send colobj :primitive_poses
                (append pose
                        (list


### PR DESCRIPTION
I replace the codes in `collision-object-publisher.l` with functions to create `shape_msgs::SolidPrimitive` object.
These functions are introduced at https://github.com/jsk-ros-pkg/jsk_roseus/pull/640

Please merge after https://github.com/jsk-ros-pkg/jsk_roseus/pull/640 is released.