### PR TITLE
[pr2eus] fix to support namespace

### DIFF
--- a/pr2eus/pr2-interface.l
+++ b/pr2eus/pr2-interface.l
@@ -60,21 +60,21 @@
    ;;
    (ros::advertise "j_robotsound" sound_play::SoundRequest 5)
    ;;
-   (ros::subscribe "/pressure/r_gripper_motor" pr2_msgs::PressureState
+   (ros::subscribe (if namespace (format nil "~A/~A" namespace "pressure/r_gripper_motor") "/pressure/r_gripper_motor") pr2_msgs::PressureState
                    #'send self :pr2-fingertip-callback :rarm-pressure :groupname groupname)
-   (ros::subscribe "/pressure/l_gripper_motor" pr2_msgs::PressureState
+   (ros::subscribe (if namespace (format nil "~A/~A" namespace "pressure/l_gripper_motor") "/pressure/l_gripper_motor") pr2_msgs::PressureState
                    #'send self :pr2-fingertip-callback :larm-pressure :groupname groupname)
-   (ros::subscribe "/r_gripper_controller/state" pr2_controllers_msgs::JointControllerState
+   (ros::subscribe (if namespace (format nil "~A/~A" namespace "r_gripper_controller/state") "/r_gripper_controller/state") pr2_controllers_msgs::JointControllerState
                    #'send self :pr2-gripper-state-callback :rarm :groupname groupname)
-   (ros::subscribe "/l_gripper_controller/state" pr2_controllers_msgs::JointControllerState
+   (ros::subscribe (if namespace (format nil "~A/~A" namespace "l_gripper_controller/state") "/l_gripper_controller/state") pr2_controllers_msgs::JointControllerState
                    #'send self :pr2-gripper-state-callback :larm :groupname groupname)
    ;;
    (setq r-gripper-action (instance ros::simple-action-client :init
-                                    "/r_gripper_controller/gripper_action"
+                                    (if namespace (format nil "~A/~A" namespace "r_gripper_controller/gripper_action") "/r_gripper_controller/gripper_action")
                                     pr2_controllers_msgs::Pr2GripperCommandAction
                                     :groupname groupname))
    (setq l-gripper-action (instance ros::simple-action-client :init
-                                    "/l_gripper_controller/gripper_action"
+                                    (if namespace (format nil "~A/~A" namespace "l_gripper_controller/gripper_action") "/l_gripper_controller/gripper_action")
                                     pr2_controllers_msgs::Pr2GripperCommandAction
                                     :groupname groupname))
    ;; wait for pr2-action server (except move_base)

--- a/pr2eus/robot-interface.l
+++ b/pr2eus/robot-interface.l
@@ -1274,14 +1274,14 @@ Return value is a list of interpolatingp for all controllers, so (null (some #'i
      (when base-controller-action-name
        (setq move-base-trajectory-action
              (instance ros::simple-action-client :init
-                       base-controller-action-name
+                       (if namespace (format nil "~A~A" namespace base-controller-action-name) base-controller-action-name)
                        control_msgs::FollowJointTrajectoryAction
                        :groupname groupname))
        (unless (send move-base-trajectory-action :wait-for-server 3)
          (ros::ros-warn "move-base-trajectory-action is not found")
          (setq move-base-trajectory-action nil))
        (setq move-base-trajectory-joint-names base-controller-joint-names))
-     (ros::subscribe odom-topic-name nav_msgs::Odometry
+     (ros::subscribe (if namespace (format nil "~A~A" namespace odom-topic-name) odom-topic-name) nav_msgs::Odometry
 		     #'send self :odom-callback :groupname groupname)
      ))
   ;;
@@ -1525,14 +1525,14 @@ Return value is a list of interpolatingp for all controllers, so (null (some #'i
    (x y d) ;; [m] [m] [degree]
    (when (send self :simulation-modep)
      (return-from :send-cmd-vel-raw t))
-   (unless (ros::get-topic-publisher cmd-vel-topic)
-     (ros::advertise cmd-vel-topic geometry_msgs::Twist 1)
+   (unless (ros::get-topic-publisher (if namespace (format nil "~A~A" namespace cmd-vel-topic) cmd-vel-topic))
+     (ros::advertise (if namespace (format nil "~A~A" namespace cmd-vel-topic) cmd-vel-topic) geometry_msgs::Twist 1)
      (unix:sleep 1))
    (let ((msg (instance geometry_msgs::Twist :init)))
      (send msg :linear :x x)
      (send msg :linear :y y)
      (send msg :angular :z d)
-     (ros::publish cmd-vel-topic msg)))
+     (ros::publish (if namespace (format nil "~A~A" namespace cmd-vel-topic) cmd-vel-topic) msg)))
   (:go-velocity
    (x y d ;; [m/sec] [m/sec] [rad/sec]
     &optional (msec 1000) ;; msec is total animation time [msec]


### PR DESCRIPTION
This PR enables to initialize `pr2-interface` under namespace.
```
(setq *ri* (instance pr2-interface :init :namespace "PR2")) 
```