### PR TITLE
[pr2-utils.l] fix :inverse-kinematics for additionnal-weight-list

### DIFF
--- a/pr2eus/pr2-utils.l
+++ b/pr2eus/pr2-utils.l
@@ -142,9 +142,12 @@
                     :thre thre
                     :stop stop
                     :additional-weight-list
-                    (list
-                     (list (send self :torso_lift_joint :child-link)
-                           (if (numberp use-torso) use-torso 0.005))
+                    (append
+                     (list
+                      (list (send self :torso_lift_joint :child-link)
+                            (if (numberp use-torso) use-torso 0.005))
+                      )
+                     additional-weight-list
                      )
                     :link-list link-list
                     :move-target move-target


### PR DESCRIPTION
`pr2-utils.l`を読んでいたところ、`use-base`が`nil`のとき、引数`additional-weight-list`が反映されていないことに気づいたので、反映されるようにしました。もし理由があって引数`additional-weight-list`が反映されないようにしていたのであれば、mergeしないでください。