### PR TITLE
[pr2eus_moveit] angle-vector-motion plan runs normal angle-vector in kinematics simulator

### DIFF
--- a/pr2eus/robot-interface.l
+++ b/pr2eus/robot-interface.l
@@ -374,7 +374,7 @@
    (let* ((prev-av (send robot :angle-vector)))
      (send-all (gethash ctype controller-table) :push-angle-vector-simulation av tm prev-av)))
   (:angle-vector
-   (av &optional (tm nil) (ctype controller-type) (start-time 0) &key (scale 1) (min-time 1.0) (end-coords-interpolation nil) (end-coords-interpolation-steps 10) (minjerk-interpolation nil))
+   (av &optional (tm nil) (ctype controller-type) (start-time 0) &key (scale 1) (min-time 1.0) (end-coords-interpolation nil) (end-coords-interpolation-steps 10) (minjerk-interpolation nil) &allow-other-keys)
    "Send joint angle to robot, this method returns immediately, so use :wait-interpolation to block until the motion stops.
 - av : joint angle vector [deg]
 - tm : (time to goal in [msec])
@@ -448,7 +448,7 @@
         cacts (send self ctype))))
    av)
   (:angle-vector-sequence
-   (avs &optional (tms (list 3000)) (ctype controller-type) (start-time 0.1) &key (scale 1) (min-time 0.0) (end-coords-interpolation nil) (end-coords-interpolation-steps 10) (minjerk-interpolation nil))
+   (avs &optional (tms (list 3000)) (ctype controller-type) (start-time 0.1) &key (scale 1) (min-time 0.0) (end-coords-interpolation nil) (end-coords-interpolation-steps 10) (minjerk-interpolation nil) &allow-other-keys)
    "Send sequence of joint angle to robot, this method returns immediately, so use :wait-interpolation to block until the motion stops.
 - avs: sequence of joint angles(float-vector) [deg],  (list av0 av1 ... avn)
 - tms: sequence of duration(float) from previous angle-vector to next goal [msec],  (list tm0 tm1 ... tmn)

--- a/pr2eus_moveit/euslisp/robot-moveit.l
+++ b/pr2eus_moveit/euslisp/robot-moveit.l
@@ -569,6 +569,11 @@
 - use-send-angle-vector : whether to use :angle-vector in robot-interface for sending trajectory
 - scale : if :fast is specified as total-time, it will use 'scale' times of the planned time
 "
+   (if (send self :simulation-modep)
+     (return-from :angle-vector-motion-plan
+                  (if (listp av)
+                    (send* self :angle-vector-sequence av total-time ctype start-offset-time args)
+                    (send* self :angle-vector av total-time ctype start-offset-time args))))
    (let (traj ret orig-total-time sent-controllers other-joints)
      (setq ctype (or ctype controller-type))
      (unless (gethash ctype controller-table)
@@ -774,6 +779,11 @@
    (av &rest args &key (ctype controller-type) (start-offset-time 0) (total-time) (use-base)
        (move-arm :larm) (reset-total-time 5000.0) (use-send-angle-vector) (scale 1.0)
        &allow-other-keys)
+   (if (send self :simulation-modep)
+     (return-from :angle-vector-motion-plan
+                  (if (listp av)
+                    (send* self :angle-vector-sequence av total-time ctype start-offset-time args)
+                    (send* self :angle-vector av total-time ctype start-offset-time args))))
    (let ((ret (send-super* :angle-vector-motion-plan av
                            :ctype ctype
                            :start-offset-time start-offset-time


### PR DESCRIPTION
this PR avoid error when we run `angle-vector-motion-plan` in `kinematics simulator`.
the way is just run `angle-vector` or `angle-vector-sequence` when `kinematics simulator` is on.
this PR is useful when we share the same code for 1) `real robot + moveit` and 2) `kinematics simulator`.
now we need to switch `angle-vector-motion-plan` and `angle-vector` for testing same code in 1) and 2).