### PR TITLE
Update current-time slot in controller-action-client on real robot

### DIFF
--- a/pr2eus/robot-interface.l
+++ b/pr2eus/robot-interface.l
@@ -45,7 +45,7 @@
     (ros::ros-debug "[~A] time-to-finish ~A" ros::name-space time-to-finish)
     time-to-finish)
   (:action-feedback-cb (msg)
-   (let ((finish-time) (current-time))
+   (let ((finish-time))
      (ros::ros-debug "[~A] feedback-cb ~A" ros::name-space msg)
      (setq last-feedback-msg-stamp (send msg :header :stamp))
      (unless (and (send ros::comm-state :action-goal)


### PR DESCRIPTION
The `controller-action-client class` has a `current-time` slot for keeping track of the `time_from_start` field in the action feedback message.
This field is only used in simulation to calculate the `time-to-finish`, but it shouldn't hurt to set it when on the real robot as well, specially since we are already calculating it.

I've found this information useful for my work on interruptions, but nevertheless this change should be discussed and tested (is the test suite working for all robots?)

@pazeshun 