### PR TITLE
add test code for (pr2) and (instance pr2-robot :init) (instance r2-sensor-robot :init)

### DIFF
--- a/pr2eus/make-pr2-model-file.l
+++ b/pr2eus/make-pr2-model-file.l
@@ -60,7 +60,7 @@
      (format f "))~%")
      (format f "~%")
      (format f "(defmethod ~A-sensor-robot~%" robot)
-     (format f "  (:init (n &rest args)~%")
+     (format f "  (:init (&optional (n :~A) &rest args)~%" (if (string= (car robot-names) "") "pr2" (car robot-names)))
      (format f "   (send-super* :init args)~%")
      (format f "   (setq name n)~%")
      ;; pr2 specific kinect_head frames

--- a/pr2eus/test/pr2-ri-test-simple.l
+++ b/pr2eus/test/pr2-ri-test-simple.l
@@ -158,6 +158,53 @@
       )
     ))
 
+;; pr2 / pr2-sensor-robot test
+(deftest instantiate-pr2-sensor-robot-test
+  (let (rgb-camera-pr1012 rgb-camera-pr1040)
+    ;; call from function
+    (pr2)
+    (assert *pr2*) ;; generate *pr2*
+    (assert (derivedp *pr2* pr2-sensor-robot)) ;; pr2 derived from pr2-sensor-robot
+    (assert (equal (send *pr2* :name) "pr2")) ;; robot name is pr2
+    (assert (equal (*pr2* . name) :pr1012)) ;; but we can know serial number
+    (setq rgb-camera-1012 (send (send *pr2* :camera :kinect_head/rgb) :viewing :projection))
+
+    (pr2 :pr1040)
+    (assert *pr2*) ;; generated *pr2*
+    (assert (derivedp *pr2* pr2-sensor-robot)) ;; pr2 derived from pr2-sensor-robot
+    (assert (equal (send *pr2* :name) "pr2")) ;; robot name is pr2
+    (assert (equal (*pr2* . name) :pr1040)) ;; but we can know serial number
+    (setq rgb-camera-1040 (send (send *pr2* :camera :kinect_head/rgb) :viewing :projection))
+    (defun m= (m1 m2) (v= (array-entity m1) (array-entity m2)))
+    (when (m= rgb-camera-1012 rgb-camera-1040)
+      (warning-message 1 "each robot should have different camera param~%~A~%~A~%"
+                       rgb-camera-1040 rgb-camera-1040))
+
+    ;; use instance
+    (setq *pr2* (instance pr2-robot :init))
+    (assert *pr2*) ;; generate *pr2*
+    (assert (derivedp *pr2* pr2-robot)) ;; pr2 derived from pr2-sensor-robot
+    (assert (equal (send *pr2* :name) "pr2")) ;; robot name is pr2
+    (assert (null (assoc 'name (send *pr2* :slots)))) ;; but it does not have slot 'name
+
+    (setq *pr2* (instance pr2-sensor-robot :init))
+    (assert *pr2*) ;; generate *pr2*
+    (assert (derivedp *pr2* pr2-robot)) ;; pr2 derived from pr2-sensor-robot
+    (assert (equal (send *pr2* :name) "pr2")) ;; robot name is pr2
+    (assert (equal (*pr2* . name) :pr1012)) ;; but we can know serial number
+
+    (setq *pr2* (instance pr2-sensor-robot :init :pr1012))
+    (assert *pr2*) ;; generated *pr2*
+    (assert (derivedp *pr2* pr2-sensor-robot)) ;; pr2 derived from pr2-sensor-robot
+    (assert (equal (send *pr2* :name) "pr2")) ;; robot name is pr2
+    (assert (equal (*pr2* . name) :pr1012)) ;; but we can know serial number
+
+    (setq *pr2* (instance pr2-sensor-robot :init :pr1040))
+    (assert *pr2*) ;; generated *pr2*
+    (assert (derivedp *pr2* pr2-sensor-robot)) ;; pr2 derived from pr2-sensor-robot
+    (assert (equal (send *pr2* :name) "pr2")) ;; robot name is pr2
+    (assert (equal (*pr2* . name) :pr1040)) ;; but we can know serial number
+    ))
 
 (run-all-tests)
 (exit)


### PR DESCRIPTION
follow ups of #426

as https://github.com/jsk-ros-pkg/jsk_robot/issues/1407#issuecomment-971313512 reported, it breaks existing API