### PR TITLE
fix jsk_pr2eus noetic travis

### DIFF
--- a/.github/workflows/noetic.yml
+++ b/.github/workflows/noetic.yml
@@ -27,4 +27,4 @@ jobs:
           ROS_PARALLEL_TEST_JOBS : "-j1"
           CATKIN_PARALLEL_TEST_JOBS : "-p1"
           ROS_DISTRO : noetic
-          USE_DEB : true
+          USE_DEB : false

--- a/.travis.rosinstall
+++ b/.travis.rosinstall
@@ -1,6 +1,0 @@
-- git:
-    uri: https://github.com/jsk-ros-pkg/openrave_planning.git
-    local-name: jsk-ros-pkg/openrave_planning
-- git:
-    uri: https://github.com/jsk-ros-pkg/jsk_roseus.git
-    local-name: jsk-ros-pkg/jsk_roseus

--- a/.travis.rosinstall.noetic
+++ b/.travis.rosinstall.noetic
@@ -1,4 +1,8 @@
-# install euscollada from source since this is not released now.
+# install jskeus and euscollada from source since this is not released now.
+- git:
+    local-name: jskeus-release
+    uri: https://github.com/tork-a/jskeus-release
+    version: release/melodic/jskeus
 - tar:
     local-name: euscollada
     uri: https://github.com/tork-a/jsk_model_tools-release/archive/refs/tags/rpm/ros-melodic-euscollada-0.4.3-0_28.tar.gz

--- a/.travis.rosinstall.noetic
+++ b/.travis.rosinstall.noetic
@@ -1,8 +1,20 @@
-# install jskeus and euscollada from source since this is not released now.
+# install jskeus from source since this is not released now.
+- git:
+    local-name: euslisp-release
+    uri: https://github.com/tork-a/euslisp-release
+    version: release/melodic/euslisp
 - git:
     local-name: jskeus-release
     uri: https://github.com/tork-a/jskeus-release
     version: release/melodic/jskeus
+# find_package(collada_urdf) failed due to wrong collada_urdfConfig.cmake
+# - https://github.com/ros/collada_urdf/issues/43
+# - https://github.com/ros/collada_urdf/pull/44
+- git:
+    local-name: collada_urdf
+    uri: https://github.com/werner291/collada_urdf.git
+    version: patch-1
+# compile euscollada for installed collada_urdf
 - tar:
     local-name: euscollada
     uri: https://github.com/tork-a/jsk_model_tools-release/archive/refs/tags/rpm/ros-melodic-euscollada-0.4.3-0_28.tar.gz

--- a/.travis.rosinstall.noetic
+++ b/.travis.rosinstall.noetic
@@ -1,0 +1,4 @@
+# install euscollada from source since this is not released now.
+- tar:
+    local-name: euscollada
+    uri: https://github.com/tork-a/jsk_model_tools-release/archive/refs/tags/rpm/ros-melodic-euscollada-0.4.3-0_28.tar.gz

--- a/.travis.rosinstall.noetic
+++ b/.travis.rosinstall.noetic
@@ -7,6 +7,9 @@
     local-name: jskeus-release
     uri: https://github.com/tork-a/jskeus-release
     version: release/melodic/jskeus
+- git:
+    uri: https://github.com/jsk-ros-pkg/jsk_roseus.git
+    local-name: jsk-ros-pkg/jsk_roseus
 # find_package(collada_urdf) failed due to wrong collada_urdfConfig.cmake
 # - https://github.com/ros/collada_urdf/issues/43
 # - https://github.com/ros/collada_urdf/pull/44

--- a/pr2eus/test/pr2eus-test.launch
+++ b/pr2eus/test/pr2eus-test.launch
@@ -12,7 +12,7 @@
 	args="-k -r 0.1 $(find pr2eus)/test/pr1012_camera_info.bag" />
   <node name="pr2_sensor_data" pkg="rosbag" type="play"
 	args="-k -r 0.1 $(find pr2eus)/test/pr1012_sensors.bag" />
-  <test test-name="pr2_read_state_test" pkg="roseus" type="roseus"
+  <test test-name="pr2_read_state_test" pkg="roseus" type="roseus" time-limit="240.0"
 	args="$(find pr2eus)/test/pr2-read-state-test.l" />
   <test test-name="pr2_ik_test" pkg="roseus" type="roseus"
 	args="$(find pr2eus)/test/pr2-ik-test.l" />

--- a/pr2eus/test/test_dummy_soundplay_node.py
+++ b/pr2eus/test/test_dummy_soundplay_node.py
@@ -226,7 +226,7 @@ class soundplay:
         elif data.sound == SoundRequest.SAY:
             if not data.arg in self.voicesounds.keys():
                 rospy.logdebug('command for uncached text: "%s"' % data.arg)
-                txtfile = tempfile.NamedTemporaryFile(prefix='sound_play', suffix='.txt')
+                txtfile = tempfile.NamedTemporaryFile(mode='w+t', prefix='sound_play', suffix='.txt')
                 (wavfile,wavfilename) = tempfile.mkstemp(prefix='sound_play', suffix='.wav')
                 txtfilename=txtfile.name
                 os.close(wavfile)

--- a/pr2eus/test/test_dummy_soundplay_node.py
+++ b/pr2eus/test/test_dummy_soundplay_node.py
@@ -170,7 +170,7 @@ class soundtype:
             pass
             # position = self.sound.query_position(gst.FORMAT_TIME)[0]
             # duration = self.sound.query_duration(gst.FORMAT_TIME)[0]
-        except Exception, e:
+        except Exception as e:
             position = 0
             duration = 0
         finally:
@@ -279,7 +279,7 @@ class soundplay:
             else:
                 sound = self.select_sound(data)
                 sound.command(data.command)
-        except Exception, e:
+        except Exception as e:
             rospy.logerr('Exception in callback: %s'%str(e))
             rospy.loginfo(traceback.format_exc())
         finally:
@@ -292,7 +292,7 @@ class soundplay:
         for (key,sound) in dict.iteritems():
             try:
                 staleness = sound.get_staleness()
-            except Exception, e:
+            except Exception as e:
                 rospy.logerr('Exception in cleanupdict for sound (%s): %s'%(str(key),str(e)))
                 staleness = 100 # Something is wrong. Let's purge and try again.
             #print "%s %i"%(key, staleness)
@@ -339,7 +339,7 @@ class soundplay:
             da.status.append(ds)
             da.header.stamp = rospy.get_rostime()
             self.diagnostic_pub.publish(da)
-        except Exception, e:
+        except Exception as e:
             rospy.loginfo('Exception in diagnostics: %s'%str(e))
 
     def execute_cb(self, data):
@@ -379,7 +379,7 @@ class soundplay:
                     rospy.loginfo('sound_play action: Succeeded')
                     self._as.set_succeeded(self._result)
 
-        except Exception, e:
+        except Exception as e:
             rospy.logerr('Exception in actionlib callback: %s'%str(e))
             rospy.loginfo(traceback.format_exc())
         finally:


### PR DESCRIPTION
Currently jsk_pr2eus noetic build fail like [here](https://github.com/jsk-ros-pkg/jsk_pr2eus/runs/4235416477?check_suite_focus=true).

One of this reason is that the noetic version of euscollada has not been released.
So euscollada should be installed from source. 
Reference is [`.travis.rosinstall.noetic`](https://github.com/jsk-ros-pkg/jsk_robot/blob/e4262cbf8932a107220dc4b7c2562a192186fd0d/.travis.rosinstall.noetic#L20-L23)
`.travis.rosinstall.noetic` is checked by [`travis.sh`](https://github.com/jsk-ros-pkg/jsk_travis/blob/5e0ae4e342f736d06b0bdaebb239bf6a260598bf/travis.sh#L337-L340).
```
2021-11-17T08:29:34.8409353Z Errors << pr2eus:cmake /github/home/ros/ws_jsk_pr2eus/logs/pr2eus/build.cmake.000.log
2021-11-17T08:29:34.8412346Z CMake Error at /opt/ros/noetic/share/catkin/cmake/catkinConfig.cmake:83 (find_package):
2021-11-17T08:29:34.8417063Z   Could not find a package configuration file provided by "euscollada" with
2021-11-17T08:29:34.8417803Z   any of the following names:
2021-11-17T08:29:34.8418107Z 
2021-11-17T08:29:34.8418577Z     euscolladaConfig.cmake
2021-11-17T08:29:34.8419506Z     euscollada-config.cmake
2021-11-17T08:29:34.8419908Z 
2021-11-17T08:29:34.8420489Z   Add the installation prefix of "euscollada" to CMAKE_PREFIX_PATH or set
2021-11-17T08:29:34.8421312Z   "euscollada_DIR" to a directory containing one of the above files.  If
2021-11-17T08:29:34.8422181Z   "euscollada" provides a separate development package or SDK, be sure it has
2021-11-17T08:29:34.8422856Z   been installed.
2021-11-17T08:29:34.8423335Z Call Stack (most recent call first):
2021-11-17T08:29:34.8424748Z   CMakeLists.txt:24 (find_package)
2021-11-17T08:29:34.8425119Z 
2021-11-17T08:29:34.8425324Z 
2021-11-17T08:29:34.8427619Z cd /github/home/ros/ws_jsk_pr2eus/build/pr2eus; catkin build --get-env pr2eus | catkin env -si  /usr/bin/cmake /github/home/ros/ws_jsk_pr2eus/src/jsk_pr2eus/pr2eus --no-warn-unused-cli -DCATKIN_DEVEL_PREFIX=/github/home/ros/ws_jsk_pr2eus/devel/.private/pr2eus -DCMAKE_INSTALL_PREFIX=/github/home/ros/ws_jsk_pr2eus/install; cd -
2021-11-17T08:29:34.8429242Z 
2021-11-17T08:29:34.8429626Z ...............................................................................
2021-11-17T08:29:34.8430152Z Failed << pr2eus:cmake                          [ Exited with code 1 ]
```
[Edited]
The other reasons to fail test are there are several unreleased packages in noetic version. 
In addition, since noetic python version is python3,  some python2 test codes fail. 

Thank you @708yamaguchi @tkmtnt7000 
