### PR TITLE
[pr2eus] Set joint-action-enable from argument

### DIFF
--- a/pr2eus/robot-interface.l
+++ b/pr2eus/robot-interface.l
@@ -121,6 +121,7 @@
           ((:controller-timeout ct) 3)
           ((:visualization-marker-topic vmt) "robot_interface_marker_array")
           ((:simulation-look-all sim-look-all) t)
+          ((:joint-action-enable jae) t)
           &allow-other-keys)
    "Create robot interface
 - robot : class name of robot
@@ -137,7 +138,7 @@
 "
    (setq joint-states-topic jst)
    (setq pub-joint-states-topic pjst)
-   (setq joint-action-enable t)
+   (setq joint-action-enable jae)
    (setq controller-timeout ct)
    (setq namespace ns)
    (setq robot (cond ((derivedp r metaclass) (instance r :init))


### PR DESCRIPTION
In this pull request, `joint-action-enable` variable can be set from the argument.

This change allows robots that do not support `follow_joint_trajectory` to set the `(send *ri* :simulation-modep)` value correctly (such as Spot) , so that kinematics-simulator can be used.

The new keyword argument is named `joint-action-enable`, which is the same name as `:joint-action-enable` in the member function.
https://github.com/jsk-ros-pkg/jsk_pr2eus/blob/27066da325b7224bb35e3c4ded05b751c96fd907/pr2eus/robot-interface.l#L1016
It seems complicate things. I couldn't think of a better name for the variable, so if someone hits on a better name (or should change the name), please let me know.

cc:@708yamaguchi