### PR TITLE
Install roseus_resume interruption handler for pr2

### DIFF
--- a/pr2eus/pr2-interface.l
+++ b/pr2eus/pr2-interface.l
@@ -82,6 +82,15 @@
        (setq joint-action-enable nil)
        (ros::ros-warn "~A is not respond, pr2-interface is disabled" action)
        (return)))
+   ;; install interruption handler
+   (warning-message 3 "Installing interruption handler...~%")
+   (roseus_resume:install-interruption-handler self
+       r-gripper-action
+       l-gripper-action
+       move-base-action
+       move-base-trajectory-action)
+   (roseus_resume:install-default-intervention self)
+   (warning-message 3 "...done.~%")
    t)
   ;;
   (:state (&rest args) ;; overwrite for jsk_maps/pr2
@@ -642,16 +651,6 @@ Example: (send self :gripper :rarm :position) => 0.00"
   (unless (boundp '*pr2*) (pr2))
   (unless (ros::ok) (ros::roseus "pr2_eus_interface"))
   (unless (boundp '*ri*) (setq *ri* (instance pr2-interface :init)))
-
-  (warning-message 3 "Installing interruption handler...~%")
-  (roseus_resume:install-interruption-handler *ri*
-      r-gripper-action
-      l-gripper-action
-      move-base-action
-      move-base-trajectory-action)
-  (roseus_resume:install-default-intervention *ri*)
-
-  (warning-message 3 "...done.~%")
 
   (ros::spin-once)
   (send *ri* :spin-once)

--- a/pr2eus/pr2-interface.l
+++ b/pr2eus/pr2-interface.l
@@ -4,8 +4,18 @@
 (require :pr2 "package://pr2eus/pr2.l")
 (require :pr2-utils "package://pr2eus/pr2-utils.l")
 (require :robot-interface "package://pr2eus/robot-interface.l")
-(require :roseus_resume "package://roseus_resume/euslisp/interruption-handler.l")
 (require :speak "package://pr2eus/speak.l")
+(defvar *enable-roseus-resume* (ros::rospack-find "roseus_resume"))
+(if *enable-roseus-resume*
+  (progn
+    (require :roseus_resume "package://roseus_resume/euslisp/interruption-handler.l")
+    (warning-message 2 "roseus_resume is enabled.~%"))
+  (progn
+    ;; make dummy package to avoid symbol search error
+    (unless (find-package "ROSEUS_RESUME") (make-package "ROSEUS_RESUME"))
+    (warning-message 3 "roseus_resume is disabled.~%")))
+
+
 
 (unless (ros::rospack-find "pr2_controllers_msgs")
   (cond ((or (string= (unix::getenv "ROS_DISTRO") "indigo")
@@ -83,12 +93,16 @@
        (ros::ros-warn "~A is not respond, pr2-interface is disabled" action)
        (return)))
    ;; install interruption handler
-   (roseus_resume:install-interruption-handler self
-       r-gripper-action
-       l-gripper-action
-       move-base-action
-       move-base-trajectory-action)
-   (roseus_resume:install-default-intervention self)
+   (if *enable-roseus-resume*
+     (progn
+       (warning-message 3 "Installing interruption handler...~%")
+       (roseus_resume::install-interruption-handler self
+           r-gripper-action
+           l-gripper-action
+           move-base-action
+           move-base-trajectory-action)
+       (roseus_resume::install-default-intervention self)
+       (warning-message 3 "...done.~%")))
    t)
   ;;
   (:state (&rest args) ;; overwrite for jsk_maps/pr2

--- a/pr2eus/pr2-interface.l
+++ b/pr2eus/pr2-interface.l
@@ -4,6 +4,7 @@
 (require :pr2 "package://pr2eus/pr2.l")
 (require :pr2-utils "package://pr2eus/pr2-utils.l")
 (require :robot-interface "package://pr2eus/robot-interface.l")
+(require :roseus_resume "package://roseus_resume/euslisp/interruption-handler.l")
 (require :speak "package://pr2eus/speak.l")
 
 (unless (ros::rospack-find "pr2_controllers_msgs")
@@ -641,6 +642,17 @@ Example: (send self :gripper :rarm :position) => 0.00"
   (unless (boundp '*pr2*) (pr2))
   (unless (ros::ok) (ros::roseus "pr2_eus_interface"))
   (unless (boundp '*ri*) (setq *ri* (instance pr2-interface :init)))
+
+  (warning-message 3 "Installing interruption handler...~%")
+  (roseus_resume:install-interruption-handler *ri*
+      r-gripper-action
+      l-gripper-action
+      move-base-action
+      move-base-trajectory-action)
+
+  (roseus_resume:defintervention interruption "/roseus_resume/interrupt" std_msgs::Empty
+                                 :groupname (*ri* . groupname))
+  (warning-message 3 "...done.~%")
 
   (ros::spin-once)
   (send *ri* :spin-once)

--- a/pr2eus/pr2-interface.l
+++ b/pr2eus/pr2-interface.l
@@ -83,14 +83,12 @@
        (ros::ros-warn "~A is not respond, pr2-interface is disabled" action)
        (return)))
    ;; install interruption handler
-   (warning-message 3 "Installing interruption handler...~%")
    (roseus_resume:install-interruption-handler self
        r-gripper-action
        l-gripper-action
        move-base-action
        move-base-trajectory-action)
    (roseus_resume:install-default-intervention self)
-   (warning-message 3 "...done.~%")
    t)
   ;;
   (:state (&rest args) ;; overwrite for jsk_maps/pr2

--- a/pr2eus/pr2-interface.l
+++ b/pr2eus/pr2-interface.l
@@ -649,9 +649,8 @@ Example: (send self :gripper :rarm :position) => 0.00"
       l-gripper-action
       move-base-action
       move-base-trajectory-action)
+  (roseus_resume:install-default-intervention *ri*)
 
-  (roseus_resume:defintervention interruption "/roseus_resume/interrupt" std_msgs::Empty
-                                 :groupname (*ri* . groupname))
   (warning-message 3 "...done.~%")
 
   (ros::spin-once)


### PR DESCRIPTION
this PR install `roseus_resume` interruption handler for `pr2-interface`.
this PR doesn't load `roseus_resume` when `roseus_resume` is not found.

cc. @Affonso-Gui 