### PR TITLE
Add roseus_resume support

### DIFF
--- a/pr2eus/robot-interface.l
+++ b/pr2eus/robot-interface.l
@@ -11,6 +11,12 @@
 (require :speak "package://pr2eus/speak.l")
 (require :actionlib-commstate "package://roseus/euslisp/actionlib-commstate.l")
 
+;; ROSEUS_RESUME
+(defvar *enable-roseus-resume*
+  #+:condition (ros::rospack-find "roseus_resume"))
+;; make dummy package to avoid symbol search error
+(unless (find-package "ROSEUS_RESUME") (make-package "ROSEUS_RESUME"))
+
 (defun shortest-angle (d0 d1)
   (atan2 (sin (- d0 d1)) (cos (- d0 d1))))
 
@@ -264,6 +270,9 @@
        (pushnew `(lambda () (send ,self :robot-interface-simulation-callback)) *timer-job*)
        (warning-message 3 "current *timer-job* is ~A~%" *timer-job*)
        ))
+   ;;
+   (when *enable-roseus-resume*
+     (roseus_resume::install-interruption-handler self))
    self)
   ;;
   (:add-controller (ctype &key (joint-enable-check) (create-actions))
@@ -2297,5 +2306,12 @@ Return value is a list of interpolatingp for all controllers, so (null (some #'i
       (require (cadr robot-name-interface-file-list))
       (funcall (eval (read-from-string (format nil "#'~A-init" robot-name))))
       ))))
+
+;; roseus_resume must be loaded after `robot-interface' definition
+(if *enable-roseus-resume*
+    (progn
+      (require :roseus_resume "package://roseus_resume/euslisp/interruption-handler.l")
+      (warning-message 2 ";; roseus_resume is enabled.~%"))
+    (warning-message 3 ";; roseus_resume is disabled.~%"))
 
 (provide :robot-interface "robot-interface.l")


### PR DESCRIPTION
Solution for https://github.com/jsk-ros-pkg/jsk_pr2eus/pull/485.

> if we need to install all action client, may be we try to find them from program code

I have taken this approach, searching and stopping all instances of `ros::simple-action-client` registered as slots in the robot-interface instance.
https://github.com/Affonso-Gui/roseus_resume/blob/eus10/euslisp/interruption-handler.l#L60-L70

The initialization code is then moved to `robot-interface`, and can be enabled by default in other robots without any modification. Roseus_resume will be automatically disabled on eus9 or when the package is not found, and can also be manually disabled by setting the `*enable-roseus-resume*` variable to `nil`.
```lisp
(setq *enable-roseus-resume* nil)
(pr2-init)
```

Other (user-defined) actions can also be registered as interruption targets by further calling the `roseus_resume:install-interruption-handler` function.
```lisp
(pr2-init)
(roseus_resume:install-interruption-handler *ri*
  my-action-client
  my-other-action-client)
```

If the user doesn't want to interrupt a certain action, this can be achieved by overwriting the `:get-action-status`, `:interrupt-angle-vector`, or `roseus_resume:on-interruption`.
The last one is preferred for local overwrites.
```lisp
(handler-bind ((roseus_resume:on-interruption
                #'(lambda (c)
                    (send *ri* :interrupt-angle-vector
                          (remove gripper-controller (send c :status))))))
  (do-something))
```