### PR TITLE
[pr2-interface.l] check :check-continuous-joint-move-over-180 when simulator mode

### DIFF
--- a/pr2eus/pr2-interface.l
+++ b/pr2eus/pr2-interface.l
@@ -422,7 +422,7 @@ Example: (send self :gripper :rarm :position) => 0.00"
   (:angle-vector-sequence
    (avs &optional (tms (list 3000)) &rest args)
    (unless (or (send self :simulation-modep) (cadr (memq :end-coords-interpolation args)))
-     (let* ((prev-av (send robot :angle-vector (send self :state :reference-vector)))
+     (let* ((prev-av (send robot :angle-vector (if (send self :simulation-modep) (send self :state :potentio-vector) (send self :state :reference-vector))))
             (len-av (length prev-av))
             (max-av (fill (instantiate float-vector len-av)  180))
             (min-av (fill (instantiate float-vector len-av) -180))

--- a/pr2eus/test/pr2-ri-test-simple-angle-vector.l
+++ b/pr2eus/test/pr2-ri-test-simple-angle-vector.l
@@ -133,6 +133,48 @@
       )
     ))
 
+(deftest test-angle-vector-unlimited-robot-interface
+  (let (msg)
+    (dolist (inc (list 10 -10))
+      (do ((i 0.0 (incf i inc)))
+          ((if (> inc 0) (<= 1000 i) (>= -1000 i)))
+        (send *pr2* :reset-manip-pose)
+        (send *ri* :robot :reset-manip-pose)
+        (send *ri* :robot-interface-simulation-callback) ;; publish robot-state
+        (let ((initial-angle (elt (send *ri* :state :potentio-vector) 5)))
+          (send *pr2* :larm :elbow-r :joint-angle i)
+          (send-message *ri* robot-interface :angle-vector (send *pr2* :angle-vector) 500)
+          (send *ri* :wait-interpolation)
+          (setq msg
+                (format nil "initial ~A, *ri* ~A, *pr2* ~A ~A~%"
+                        initial-angle
+                        (elt (send *ri* :state :potentio-vector) 5)
+                        (elt (send *pr2* :angle-vector) 5)
+                        (eps<= (abs (- (elt (send *ri* :state :potentio-vector) 5) initial-angle)) 180.0 1.0)))
+          (warning-message 2 msg)
+          (assert (eps<= (abs (- (elt (send *ri* :state :potentio-vector) 5) initial-angle)) 180.0 1.0) msg))))))
+
+(deftest test-angle-vector-unlimited-pr2-interface
+  (let (msg)
+    (dolist (inc (list 10 -10))
+      (do ((i 0.0 (incf i inc)))
+          ((if (> inc 0) (<= 1000 i) (>= -1000 i)))
+        (send *pr2* :reset-manip-pose)
+        (send *ri* :robot :reset-manip-pose)
+        (send *ri* :robot-interface-simulation-callback) ;; publish robot-state
+        (let ((initial-angle (elt (send *ri* :state :potentio-vector) 5)))
+          (send *pr2* :larm :elbow-r :joint-angle i)
+          (send-message *ri* pr2-interface :angle-vector (send *pr2* :angle-vector) 500)
+          (send *ri* :wait-interpolation)
+          (setq msg
+                (format nil "initial ~A, *ri* ~A, *pr2* ~A ~A~%"
+                        initial-angle
+                        (elt (send *ri* :state :potentio-vector) 5)
+                        (elt (send *pr2* :angle-vector) 5)
+                        (eps= (elt (send *ri* :state :potentio-vector) 5) (elt (send *pr2* :angle-vector) 5) 1.0)))
+          (warning-message 2 msg)
+          (assert (eps= (elt (send *ri* :state :potentio-vector) 5) (elt (send *pr2* :angle-vector) 5) 1.0) msg))))))
+
 
 (run-all-tests)
 (exit)


### PR DESCRIPTION
fixed version of  #452

4168df3 (Naoki-Hiraoka, 1 year, 11 months ago)
    [pr2eus/pr2-ri-test-rimple.l] add unlimited joint test

1e70f48 (Naoki-Hiraoka, 1 year, 11 months ago)
    [pr2-interface.l] check :check-continuous-joint-move-over-180 when
    simulator mode