### PR TITLE
[pr2eus] Add header timestamp to actiongoal topic in play-sound

### DIFF
--- a/pr2eus/speak.l
+++ b/pr2eus/speak.l
@@ -43,6 +43,7 @@
           (when (eq (send ac :get-state) actionlib_msgs::GoalStatus::*active*)
             (send ac :cancel-goal)
             (send ac :wait-for-result :timeout 10))
+          (send goal :header :stamp (ros::time-now))
           (send goal :goal :sound_request msg)
           (setf (gethash topic-name *sound-play-clients*) ac)
           (send ac :send-goal goal)


### PR DESCRIPTION
Now, when we execute something like `(send *ri* :speak-jp "こんにちは")`, sound action goal topic has no headertimestamp.
I fixed it in this PR.
```
# before this PR
$ rostopic echo /robotsound_jp/goal
header: 
  seq: 0
  stamp: 
    secs: 0
    nsecs:         0
  frame_id: ''
goal_id: 
  stamp: 
    secs: 0
    nsecs:         0
  id: "1686130902134708426_/fetch_eus_interface_1686130898541295371_2753725_robotsound_jp_0"
goal: 
  sound_request: 
    sound: -3
    command: 1
    volume: 1.0
    arg: "\u3053\u3053\u304Cdock\u3067\u3059"
    arg2: "ja"

```