### PR TITLE
[pr2eus_moveit] align the center of primitive cylinder between eus and moveit

### DIFF
--- a/pr2eus_moveit/euslisp/collision-object-publisher.l
+++ b/pr2eus_moveit/euslisp/collision-object-publisher.l
@@ -78,7 +78,6 @@
                                   :dimensions (float-vector
                                                (/ (height-of-cylinder obj) 1000.0)
                                                (/ (radius-of-cylinder obj) 1000.0))))))
-         ;; Adjust the pose in the message to align EusLisp cylinder (origin at base) with MoveIt cylinder (origin at center).
          (send colobj :primitive_poses
                (append pose
                        (list
@@ -87,7 +86,8 @@
                                                                  (send obj :worldcoords)))
                                                      (hv (float-vector 0 0 (/ (height-of-cylinder obj) 2)))
                                                      (hv-t (send coords :transform-vector hv)))
-                                                     (make-coords :pos hv-t :rot (send coords :rot)))))))))
+                                                ;; Adjust the pose in the message to align EusLisp cylinder (origin at base) with MoveIt cylinder (origin at center).
+                                                (make-coords :pos hv-t :rot (send coords :rot)))))))))
       ((and (derivedp obj body) (eq (car (send obj :body-type)) :cube))
        (let ((geom (send colobj :primitives))
              (pose (send colobj :primitive_poses)))

--- a/pr2eus_moveit/euslisp/collision-object-publisher.l
+++ b/pr2eus_moveit/euslisp/collision-object-publisher.l
@@ -81,7 +81,12 @@
          (send colobj :primitive_poses
                (append pose
                        (list
-                        (ros::coords->tf-pose (if relative-pose relative-pose (send obj :worldcoords))))))))
+                        (ros::coords->tf-pose (let ((coords (if relative-pose
+                                                             relative-pose
+                                                             (send obj :worldcoords))))
+                                               (let* ((hv (float-vector 0 0 (/ (height-of-cylinder obj) 2)))
+                                                      (hv-t (send coords :transform-vector hv)))
+                                                 (make-coords :pos hv-t :rot (send coords :rot))))))))))
       ((and (derivedp obj body) (eq (car (send obj :body-type)) :cube))
        (let ((geom (send colobj :primitives))
              (pose (send colobj :primitive_poses)))

--- a/pr2eus_moveit/euslisp/collision-object-publisher.l
+++ b/pr2eus_moveit/euslisp/collision-object-publisher.l
@@ -81,12 +81,12 @@
          (send colobj :primitive_poses
                (append pose
                        (list
-                        (ros::coords->tf-pose (let ((coords (if relative-pose
-                                                             relative-pose
-                                                             (send obj :worldcoords))))
-                                               (let* ((hv (float-vector 0 0 (/ (height-of-cylinder obj) 2)))
-                                                      (hv-t (send coords :transform-vector hv)))
-                                                 (make-coords :pos hv-t :rot (send coords :rot))))))))))
+                        (ros::coords->tf-pose (let* ((coords (if relative-pose
+                                                                 relative-pose
+                                                                 (send obj :worldcoords)))
+                                                     (hv (float-vector 0 0 (/ (height-of-cylinder obj) 2)))
+                                                     (hv-t (send coords :transform-vector hv)))
+                                                     (make-coords :pos hv-t :rot (send coords :rot)))))))))
       ((and (derivedp obj body) (eq (car (send obj :body-type)) :cube))
        (let ((geom (send colobj :primitives))
              (pose (send colobj :primitive_poses)))

--- a/pr2eus_moveit/euslisp/collision-object-publisher.l
+++ b/pr2eus_moveit/euslisp/collision-object-publisher.l
@@ -78,6 +78,7 @@
                                   :dimensions (float-vector
                                                (/ (height-of-cylinder obj) 1000.0)
                                                (/ (radius-of-cylinder obj) 1000.0))))))
+         ;; Adjust the pose in the message to align EusLisp cylinder (origin at base) with MoveIt cylinder (origin at center).
          (send colobj :primitive_poses
                (append pose
                        (list


### PR DESCRIPTION
The centor of primitvie cylinder is not matched between eus and moveit.

I added transformation code to align the center of the EUS model with the MoveIt model in the definition of the pose for the cylinder's solid primitive messages.

refer to following figures 

in eus 
![Screenshot from 2024-12-05 15-27-03](https://github.com/user-attachments/assets/0ea801eb-b4a6-4125-af46-90dd24564a58)

in moveit (only cylinder models are not matched.)
![Screenshot from 2024-12-05 15-27-59](https://github.com/user-attachments/assets/7217f3b4-2c0e-48ec-b4b5-146c0ee74dac)

PR
![Screenshot from 2024-12-05 15-27-35](https://github.com/user-attachments/assets/648397f0-e5d5-4c02-8ecf-4b3379844bef)

