### PR TITLE
Skip circular dependency when building ROS-O package

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -72,7 +72,10 @@ jobs:
             TEST_PKGS: "pr2eus_moveit pr2eus_tutorials"
 
 
-    container: ${{ matrix.CONTAINER }}
+    container:
+      image: ${{ matrix.CONTAINER }}
+      volumes:
+        - /tmp/node20:/__e/node20
 
     steps:
       - name: Install latest git ( use sudo for ros-ubuntu )
@@ -95,6 +98,21 @@ jobs:
           else
              git config --global --add safe.directory $GITHUB_WORKSPACE
           fi
+
+      - name: Try to replace `node` with an glibc 2.17
+        shell: bash
+        run: |
+          if [ "${{ matrix.CONTAINER }}" = "jskrobotics/ros-ubuntu:14.04" ]; then
+             export USER=$(whoami)
+             sudo chmod 777 -R /__e/node20
+             sudo chown -R $USER /__e/node20
+          fi
+          ls -lar /__e/node20 &&
+          sudo apt-get install -y curl &&
+          curl -Lo /tmp/node.tar.gz https://unofficial-builds.nodejs.org/download/release/v20.17.0/node-v20.17.0-linux-x64-glibc-217.tar.gz &&
+          cd /__e/node20 &&
+          tar -x --strip-components=1 -f /tmp/node.tar.gz &&
+          ls -lar /__e/node20/bin/
 
       - name: Checkout
         uses: actions/checkout@v3.0.2

--- a/pr2eus_tutorials/package.xml
+++ b/pr2eus_tutorials/package.xml
@@ -28,8 +28,10 @@
   <exec_depend>jsk_interactive_marker</exec_depend>
   <exec_depend>jsk_recognition_msgs</exec_depend>
   <exec_depend>jsk_rviz_plugins</exec_depend>
-  <exec_depend>jsk_pr2_startup</exec_depend>
-  <exec_depend>jsk_maps</exec_depend>
+  <!-- jsk_pr2_startup is provided from jsk_robot, this is circular dependency -->
+  <exec_depend condition="$ROS_DISTRO != debian">jsk_pr2_startup</exec_depend>
+  <!-- jsk_maps is provided from jsk_demos, this is circular dependency -->
+  <exec_depend condition="$ROS_DISTRO != debian">jsk_maps</exec_depend>
   <exec_depend>jsk_pcl_ros</exec_depend>
 
   <!-- Dependencies needed only for running tests. -->

--- a/pr2eus_tutorials/package.xml
+++ b/pr2eus_tutorials/package.xml
@@ -1,4 +1,4 @@
-<package>
+<package format="3">
   <name>pr2eus_tutorials</name>
   <version>0.3.15</version>
   <description>pr2eus_tutorials</description>
@@ -18,19 +18,19 @@
   <build_depend>pr2eus</build_depend>
 
   <!-- Dependencies needed after this package is compiled. -->
-  <run_depend>app_manager</run_depend>
-  <run_depend>eusurdf</run_depend>
-  <run_depend>pr2_gazebo</run_depend>
-  <run_depend>pr2eus</run_depend>
-  <run_depend>roseus_tutorials</run_depend>
-  <run_depend>image_view2</run_depend>
-  <run_depend>jsk_pcl_ros</run_depend>
-  <run_depend>jsk_interactive_marker</run_depend>
-  <run_depend>jsk_recognition_msgs</run_depend>
-  <run_depend>jsk_rviz_plugins</run_depend>
-  <run_depend>jsk_pr2_startup</run_depend>
-  <run_depend>jsk_maps</run_depend>
-  <run_depend>jsk_pcl_ros</run_depend>
+  <exec_depend>app_manager</exec_depend>
+  <exec_depend>eusurdf</exec_depend>
+  <exec_depend>pr2_gazebo</exec_depend>
+  <exec_depend>pr2eus</exec_depend>
+  <exec_depend>roseus_tutorials</exec_depend>
+  <exec_depend>image_view2</exec_depend>
+  <exec_depend>jsk_pcl_ros</exec_depend>
+  <exec_depend>jsk_interactive_marker</exec_depend>
+  <exec_depend>jsk_recognition_msgs</exec_depend>
+  <exec_depend>jsk_rviz_plugins</exec_depend>
+  <exec_depend>jsk_pr2_startup</exec_depend>
+  <exec_depend>jsk_maps</exec_depend>
+  <exec_depend>jsk_pcl_ros</exec_depend>
 
   <!-- Dependencies needed only for running tests. -->
   <test_depend>rostest</test_depend>

--- a/pr2eus_tutorials/package.xml
+++ b/pr2eus_tutorials/package.xml
@@ -16,7 +16,6 @@
 
   <!-- Dependencies needed to compile this package. -->
   <build_depend>pr2eus</build_depend>
-  <build_depend>jsk_pcl_ros</build_depend>
 
   <!-- Dependencies needed after this package is compiled. -->
   <run_depend>app_manager</run_depend>
@@ -31,6 +30,7 @@
   <run_depend>jsk_rviz_plugins</run_depend>
   <run_depend>jsk_pr2_startup</run_depend>
   <run_depend>jsk_maps</run_depend>
+  <run_depend>jsk_pcl_ros</run_depend>
 
   <!-- Dependencies needed only for running tests. -->
   <test_depend>rostest</test_depend>


### PR DESCRIPTION
pr2eus_tutorials/package.xml: skip jsk_pr2_startup and jsk_maps when ROS_DISTRO==debian, as they are circular dependency