### PR TITLE
Add spin once option

### DIFF
--- a/pr2eus/pr2-interface.l
+++ b/pr2eus/pr2-interface.l
@@ -408,16 +408,17 @@ Example: (send self :gripper :rarm :position) => 0.00"
        (incf i (send j :joint-dof)))
      add-new-trajectory-point))
   (:angle-vector
-   (av &optional (tm 3000) &rest args)
+   (av &optional (tm 3000) (ctype controller-type) (start-time 0) &key (spin-once t) &rest args)
    (let (diff-av)
-     ;; use reference-vector to get last commanded joint and use :angle-vector to toruncate the joint limit to eus lisp style
-     (setq diff-av (v- av (send robot :angle-vector (send self :state :reference-vector))))
+     ;; use reference-vector to get last commanded joint and use :angle-vector to truncate the joint limit to eus lisp style
+     (if spin-once
+         (setq diff-av (v- av (send robot :angle-vector (send self :state :reference-vector))))
+         (setq diff-av (v- av (send self :potentio-vector)))) ;; calculate joint difference based on the previous state
      ;; use shortest path for contiuous joint
-     ;;
      (when (send self :check-continuous-joint-move-over-180 diff-av)
        (return-from :angle-vector
          (send* self :angle-vector-sequence (list av) (list tm) args))) ;; when
-     (send-super* :angle-vector av tm args)
+     (send-super* :angle-vector av tm ctype start-time :spin-once spin-once args)
      ))
   (:angle-vector-sequence
    (avs &optional (tms (list 3000)) &rest args)

--- a/pr2eus/robot-interface.l
+++ b/pr2eus/robot-interface.l
@@ -428,7 +428,7 @@
    (let* ((prev-av (send robot :angle-vector)))
      (send-all (gethash ctype controller-table) :push-angle-vector-simulation av tm prev-av)))
   (:angle-vector
-   (av &optional (tm nil) (ctype controller-type) (start-time 0) &key (scale 1) (min-time 1.0) (end-coords-interpolation nil) (end-coords-interpolation-steps 10) (minjerk-interpolation nil) &allow-other-keys)
+   (av &optional (tm nil) (ctype controller-type) (start-time 0) &key (scale 1) (min-time 1.0) (end-coords-interpolation nil) (end-coords-interpolation-steps 10) (minjerk-interpolation nil) (spin-once t) &allow-other-keys)
    "Send joint angle to robot, this method returns immediately, so use :wait-interpolation to block until the motion stops.
 - av : joint angle vector [deg]
 - tm : (time to goal in [msec])
@@ -442,6 +442,7 @@
 - end-coords-interpolation : set t if you want to move robot in cartesian space interpolation
 - end-coords-interpolation-steps : number of divisions when interpolating end-coords
 - minjerk-interpolation : set t if you want to move robot with minjerk interpolation
+- spin-once : set nil to skip ROS groupname callbacks (no state update), enabling faster loop rate but it doesn't safe
 "
    (if end-coords-interpolation
      (return-from :angle-vector (send self :angle-vector-sequence (list av) (list tm) ctype start-time :scale scale :min-time min-time :end-coords-interpolation t :end-coords-interpolation-steps end-coords-interpolation-steps)))
@@ -450,16 +451,19 @@
      (warn ";; controller-type: ~A not found" ctype)
      (return-from :angle-vector))
    ;;Check and decide tm
-   (let ((fastest-tm (* 1000 (send self :angle-vector-duration 
-                                   (send self :state :potentio-vector) av scale min-time ctype))))
+   (let ((fastest-tm (if spin-once
+                         (* 1000 (send self :angle-vector-duration
+                                       (send self :state :potentio-vector) av scale min-time ctype))
+                         1000))) ;; for safety, set tm to 1000 ms when :spin-once is nil
      (cond
       ;;Fastest time Mode
       ((equal tm :fast)
        (setq tm fastest-tm))
       ;;Normal Number designated Mode
       ((numberp tm)
-       (if (< tm fastest-tm)
-           (setq tm fastest-tm)))
+       (if spin-once
+           (if (< tm fastest-tm)
+               (setq tm fastest-tm)))) ;; maybe it would need additional safe condition when :spin-once is nil
       ;;Safe Mode (Speed will be 5 * fastest-tm)
       ((null tm)
        (setq tm (* 5 fastest-tm)))
@@ -498,7 +502,8 @@
             (send self :send-ros-controller
                   action (cdr (assoc :joint-names param)) ;; action server and joint-names
                   start-time  ;; start time
-                  trajpoints))
+                  trajpoints
+                  :spin-once spin-once))
         cacts (send self ctype))))
    av)
   (:angle-vector-sequence
@@ -816,7 +821,7 @@ Return value is a list of interpolatingp for all controllers, so (null (some #'i
   (:stamp () "Returns the stamp which was read at latest callback" (send self :get-robot-state :stamp))
   ;;
   (:send-ros-controller
-   (action joint-names starttime trajpoints)
+   (action joint-names starttime trajpoints &key (spin-once t))
    (when (send self :simulation-modep)
      (return-from :send-ros-controller nil))
    (if (and warningp
@@ -845,7 +850,7 @@ Return value is a list of interpolatingp for all controllers, so (null (some #'i
 	      )
 	 (send goal :goal :position pos)
 	 (send goal :goal :max_velocity 5)
-	 (send self :spin-once)
+     (if spin-once (send self :spin-once)) ;; ignore spin-once for groupname to maintain faster loop rate
 	 )
        )
       (t
@@ -886,7 +891,7 @@ Return value is a list of interpolatingp for all controllers, so (null (some #'i
 			   :time_from_start (ros::time duration))
 		 goal-points)
 	   ))
-       (send self :spin-once)
+       (if spin-once (send self :spin-once)) ;; ignore spin-once for groupname to maintain faster loop rate
        (send goal :goal :trajectory :points goal-points)
        ))
      (send action :send-goal goal)


### PR DESCRIPTION

### Summary 
This PR adds a new keyword argument :spin-once to both :angle-vector and :send-ros-controller, allowing users to skip ROS groupname callbacks (ros::spin-once groupname). By setting :spin-once to nil, unnecessary robot state updates can be avoided, leading to significantly faster control loop frequencies.
Additionally, I modified :angle-vector in pr2_interface.l to support the :spin-once option. When :spin-once is set to nil, the calculation of diff-av for check-continuous-joint-move-over-180 uses the cached previous robot state in *ri* instead of calling ros::spin-once. (This has been tested in simulation but not on a real robot. I'm slightly concerned about cases where the initial state of the real robot significantly differs from the virtual robot's state.)

---
### Motivation
When ros::spin-once is executed for each groupname, it can introduce considerable latency, especially in a tight control loop. For instance, the loop frequency can drop to around 25Hz (as shown in the figure below) due to callback overhead.
In cases where :angle-vector is only used to send commands (without needing immediate state feedback), skipping these callbacks enables maintaining a loop rate of 500Hz or higher (as shown in the figure below). To support this, :spin-once was added as an optional parameter.
However, since fastest-tm calculation depends on up-to-date robot states, setting :spin-once to nil disables this. As a workaround, the time (tm) is explicitly set to 1000ms, which is assumed to be a reasonably safe default (though this value may need further validation).
Additionally, if tm is explicitly provided by the user while :spin-once is nil, it is accepted as-is — including values below 1000ms. While this may require more safety checks in the future, it's assumed the user can make reasonable decisions when prioritizing high-frequency loop control.

![Figure_1](https://github.com/user-attachments/assets/60d3bfae-2586-43cc-888e-3ccbdeea8140)
![Figure_0](https://github.com/user-attachments/assets/8fc8bf7b-750f-42d4-af58-74f23156f6c4)

This is the test code I used when I made the plots.
```lisp
#!/usr/bin/env roseus
(require :pr2 "package://pr2eus/pr2-interface.l")
(ros::load-ros-package "geometry_msgs")
(ros::load-ros-package "std_msgs")

(unless (boundp '*pr2*) (pr2-init))

(defun log-benchmark-results (fn log-path log_prefix)
  (let ((results (bench2 (funcall fn))))
    (with-open-file (stream (format nil "log_pr2/~A_~A" log_prefix log-path) :direction :output :if-exists :append :if-does-not-exist :create)
        (format stream "~A~%" results))
    results))

(send *pr2* :reset-pose)
(send *ri* :angle-vector (send *pr2* :angle-vector))
(send *ri* :wait-interpolation)

(dotimes (i 100)
  (send *pr2* :rarm :move-end-pos #f(1 0 0) :world)
  (log-benchmark-results
     #'(lambda ()
         (send *ri* :angle-vector (send *pr2* :angle-vector) 1000 :default-controller 0 :spin-once t)
         )
     "log_angle_vector_raw.txt" "1"))

(send *pr2* :reset-pose)
(send *ri* :angle-vector (send *pr2* :angle-vector))
(send *ri* :wait-interpolation)

(dotimes (i 100)
  (send *pr2* :rarm :move-end-pos #f(1 0 0) :world)
  (log-benchmark-results
     #'(lambda ()
         (send *ri* :angle-vector (send *pr2* :angle-vector) 1000 :default-controller 0 :spin-once nil)
         )
     "log_angle_vector_raw.txt" "0"))

```
---
### Suggestions
- Further testing or evaluation may be needed to confirm whether 1000ms is a sufficiently safe default time when skipping state updates.
- The use of cached robot states in *ri* when :spin-once is nil should be validated, especially in scenarios where the real robot's initial state diverges significantly from the virtual state.
- In safety-critical applications, developers should be cautious when disabling callbacks and ensure that control logic does not rely on stale state information.

